### PR TITLE
Remove api from dmz.

### DIFF
--- a/api/src/main/scala/ApiAliases.scala
+++ b/api/src/main/scala/ApiAliases.scala
@@ -41,6 +41,7 @@ trait ApiAliases extends scala.Any {
   type Shower[-A]    = A => String
   type Suspended[+A] = (A => Unit) => Unit
   type Unary[A]      = A => A
+  type Bag[A]        = ExMap[A, Precise]
 }
 
 // Necessary to use those aliases within the api package.

--- a/dmz/src/main/scala/ScalaLibrary.scala
+++ b/dmz/src/main/scala/ScalaLibrary.scala
@@ -5,11 +5,10 @@ import scala._
 import scala.{ collection => sc }
 import sc.{ generic => scg, mutable => scm, immutable => sci }
 import java.nio.{ file => jnf }
-import psp.std.api._
 
 /** Building a default namespace consciously rather than accretively.
  */
-trait ScalaLibrary extends Any with ApiAliases {
+trait ScalaLibrary extends Any {
   type BigDecimal                      = scala.math.BigDecimal
   type BigInt                          = scala.math.BigInt
   type CanBuildFrom[-From, -Elem, +To] = scg.CanBuildFrom[From, Elem, To]
@@ -76,7 +75,6 @@ trait ScalaLibrary extends Any with ApiAliases {
   type Array3[A]                 = Array[Array[Array[A]]]
   type Array4[A]                 = Array[Array[Array[Array[A]]]]
   type Array5[A]                 = Array[Array[Array[Array[Array[A]]]]]
-  type Bag[A]                    = ExMap[A, Precise]
   type Bytes                     = Array[Byte]
   type CTag[A]                   = scala.reflect.ClassTag[A]
   type CanBuildSelf[-Elem, Self] = scg.CanBuildFrom[Self, Elem, Self]

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -79,8 +79,8 @@ object Build extends sbt.Build {
   )
 
   lazy val api    = project setup "psp's non-standard api"
-  lazy val dmz    = project setup "psp's non-standard dmz" dependsOn api
-  lazy val std    = project setup "psp's non-standard standard library" dependsOn dmz also (guava, jsr305)
+  lazy val dmz    = project setup "psp's non-standard dmz"
+  lazy val std    = project setup "psp's non-standard standard library" dependsOn (api, dmz) also (guava, jsr305)
   lazy val pio    = project setup "psp's non-standard io library" dependsOn std
   lazy val jvm    = project.usesCompiler.usesParsers setup "psp's non-standard jvm code" dependsOn pio
   lazy val dev    = project setup "psp's non-standard unstable code" dependsOn std

--- a/std/src/main/scala/Implicits.scala
+++ b/std/src/main/scala/Implicits.scala
@@ -23,6 +23,7 @@ abstract class StdPackage
          with GlobalShow
          with StdGateways
          with lowlevel.StdArrowAssoc
+         with ApiAliases
          with PolicyDmz {
 
   implicit class ApiOrderOps[A](val ord: Order[A]) {


### PR DESCRIPTION
Inspire by your ticket in cats, I realised that in its current form, there was
only so little that force dmz to pull in api.

That being said, I'm not sure if doing this makes sense according to your idea
of how psp-std hangs together, or should be used.