### PR TITLE
Move psp-api from psp.std.api to psp.api

### DIFF
--- a/api/src/main/java/psp/api/Cmp.java
+++ b/api/src/main/java/psp/api/Cmp.java
@@ -1,4 +1,4 @@
-package psp.std.api;
+package psp.api;
 
 public enum Cmp {
   LT(-1), EQ(0), GT(1);

--- a/api/src/main/java/psp/api/PCmp.java
+++ b/api/src/main/java/psp/api/PCmp.java
@@ -1,4 +1,4 @@
-package psp.std.api;
+package psp.api;
 
 public enum PCmp {
   LT(-1), EQ(0), GT(1), NA(2);

--- a/api/src/main/scala/Api.scala
+++ b/api/src/main/scala/Api.scala
@@ -57,7 +57,7 @@ trait Extensional[+A]     extends Any with Each[A]
 trait ExSet[A]            extends Any with Extensional[A] with InSet[A]         { def hashEq: HashEq[A] }
 trait ExMap[K, +V]        extends Any with Extensional[(K, V)] with InMap[K, V] { def domain: ExSet[K]  }
 
-/** Ennhanced value representations.
+/** Enhanced value representations.
  */
 trait IndexRange extends Any with Direct[Index] {
   def start: Index

--- a/api/src/main/scala/Api.scala
+++ b/api/src/main/scala/Api.scala
@@ -1,5 +1,4 @@
 package psp
-package std
 package api
 
 import scala.Any

--- a/api/src/main/scala/ApiAliases.scala
+++ b/api/src/main/scala/ApiAliases.scala
@@ -1,5 +1,4 @@
 package psp
-package std
 package api
 
 // This mostly consists of "magic" types which cannot be avoided due to language privilege.

--- a/api/src/main/scala/Size.scala
+++ b/api/src/main/scala/Size.scala
@@ -1,5 +1,4 @@
 package psp
-package std
 package api
 
 import scala._

--- a/api/src/main/scala/UnstableApi.scala
+++ b/api/src/main/scala/UnstableApi.scala
@@ -1,5 +1,4 @@
 package psp
-package std
 package api
 
 import scala._

--- a/api/src/main/scala/View.scala
+++ b/api/src/main/scala/View.scala
@@ -1,5 +1,4 @@
 package psp
-package std
 package api
 
 import ApiAliases._

--- a/consoleOnly/src/main/resources/initialCommands.scala
+++ b/consoleOnly/src/main/resources/initialCommands.scala
@@ -1,6 +1,6 @@
 import scala.collection.{ mutable => scm, immutable => sci }
 import java.nio.{ file => jnf }
-import psp.api._, psp.dmz._ psp.std._, ansi._, pio._, scalac._, jvm._, cache._
+import psp.api._, psp.dmz._, psp.std._, ansi._, pio._, scalac._, jvm._, cache._
 import StdEq._, StdShow._, StdZero._, StdMonoid._
 import psp.std.repl.ReplImport._
 

--- a/consoleOnly/src/main/resources/initialCommands.scala
+++ b/consoleOnly/src/main/resources/initialCommands.scala
@@ -1,6 +1,6 @@
 import scala.collection.{ mutable => scm, immutable => sci }
 import java.nio.{ file => jnf }
-import psp.std._, api._, ansi._, pio._, scalac._, jvm._, cache._
+import psp.api._, psp.dmz._ psp.std._, ansi._, pio._, scalac._, jvm._, cache._
 import StdEq._, StdShow._, StdZero._, StdMonoid._
 import psp.std.repl.ReplImport._
 

--- a/dev/src/main/scala/Has.scala
+++ b/dev/src/main/scala/Has.scala
@@ -12,11 +12,11 @@ object Has {
   trait Tail[R]      extends Any with ElemType    { def hasTail(xs: R): R                                   }
   trait Head[-R]     extends Any with ElemType    { def hasHead(xs: R): Elem                                }
   trait IsEmpty[-R]  extends Any                  { def hasIsEmpty(xs: R): Boolean                          }
-  trait Size[-R]     extends Any with ElemType    { def hasSize(xs: R): api.Size                            }
+  trait Size[-R]     extends Any with ElemType    { def hasSize(xs: R): psp.api.Size                        }
   trait Contains[-R] extends Any with ElemType    { def hasContains(xs: R)(x: Elem): Boolean                }
-  trait Each[-R]  extends Any with ElemType    { def hasForeach(xs: R)(f: Elem => Unit): Unit            }
+  trait Each[-R]     extends Any with ElemType    { def hasForeach(xs: R)(f: Elem => Unit): Unit            }
   trait Filter[R]    extends Any with ElemType    { def hasFilter(xs: R)(p: Predicate[Elem]): R             }
-  trait Index[-R]    extends Any with ElemType    { def hasIndex(xs: R)(index: api.Index): Elem             }
+  trait Index[-R]    extends Any with ElemType    { def hasIndex(xs: R)(index: psp.api.Index): Elem         }
   trait View[R]      extends Any with ElemType    { def hasView(xs: R): View[Elem]                          }
   trait Apply[-R]    extends Any with ApplyType   { def hasApply(xs: R)(in: In): Out                        }
   trait Map[R]       extends Any with Is.Packaged { def hasMap[A](xs: R)(f: Elem => A): CC[A]               }

--- a/dev/src/main/scala/Nat.scala
+++ b/dev/src/main/scala/Nat.scala
@@ -1,66 +1,67 @@
 package psp
-package std
 
 package api {
-  trait HasStaticSize[N <: Nat] extends Any with HasPreciseSize
-  trait Nat extends Any
+  trait HasStaticSize[N <: Nat] extends scala.Any with psp.api.HasPreciseSize
+  trait Nat extends scala.Any
 }
 
-sealed trait Nat extends api.Nat {
-  type This <: Nat
-  type Prev <: Nat { type Succ <: This }
-  type Succ <: Nat { type Prev <: This }
+package std {
+  sealed trait Nat extends psp.api.Nat {
+    type This <: Nat
+    type Prev <: Nat { type Succ <: This }
+    type Succ <: Nat { type Prev <: This }
+  }
+
+  // Meaning Nat[ Prev This Succ ]
+  sealed trait NatPTS[P <: Nat, T <: Nat, S <: Nat] extends Nat {
+    type This = T
+    type Prev = P { type Succ = This }
+    type Succ = S { type Prev = This }
+  }
+
+  object Nat {
+    final class _0 extends NatPTS[Nothing, _0, _1]
+    final class _1 extends NatPTS[_0, _1, _2]
+    final class _2 extends NatPTS[_1, _2, _3]
+    final class _3 extends NatPTS[_2, _3, _4]
+    final class _4 extends NatPTS[_3, _4, _5]
+    final class _5 extends NatPTS[_4, _5, _6]
+    final class _6 extends NatPTS[_5, _6, _7]
+    final class _7 extends NatPTS[_6, _7, _8]
+    final class _8 extends NatPTS[_7, _8, _9]
+    final class _9 extends NatPTS[_8, _9, ??]
+    final class ?? extends NatPTS[??, ??, ??]
+
+    final val _0: _0  = new _0
+    final val _1: _1  = new _1
+    final val _2: _2  = new _2
+    final val _3: _3  = new _3
+    final val _4: _4  = new _4
+    final val _5: _5  = new _5
+    final val _6: _6  = new _6
+    final val _7: _7  = new _7
+    final val _8: _8  = new _8
+    final val _9: _9  = new _9
+    final val ?? : ?? = new ??
+  }
+
+  // Attempts to use Nat.this.type as refinements of the abstract
+  // successor and predecessor types run into compilation time
+  // exponential explosion. Timing notes:
+  //
+  // Largest source alias is _6
+  // Largest existential created is _3220.type
+  // 3.555 real, 7.164 user, 0.202 sys
+  //
+  // Largest source alias is _7
+  // Largest existential created is _22432.type
+  // 6.056 real, 11.557 user, 0.416 sys
+  //
+  // Largest source alias is _8
+  // Largest existential created is _156892.type
+  // 20.183 real, 29.146 user, 1.645 sys
+  //
+  // Largest source alias is _9
+  // Largest existential created is _1098088.type
+  // 869.508 real, 902.972 user, 16.297 sys
 }
-
-// Meaning Nat[ Prev This Succ ]
-sealed trait NatPTS[P <: Nat, T <: Nat, S <: Nat] extends Nat {
-  type This = T
-  type Prev = P { type Succ = This }
-  type Succ = S { type Prev = This }
-}
-
-object Nat {
-  final class _0 extends NatPTS[Nothing, _0, _1]
-  final class _1 extends NatPTS[_0, _1, _2]
-  final class _2 extends NatPTS[_1, _2, _3]
-  final class _3 extends NatPTS[_2, _3, _4]
-  final class _4 extends NatPTS[_3, _4, _5]
-  final class _5 extends NatPTS[_4, _5, _6]
-  final class _6 extends NatPTS[_5, _6, _7]
-  final class _7 extends NatPTS[_6, _7, _8]
-  final class _8 extends NatPTS[_7, _8, _9]
-  final class _9 extends NatPTS[_8, _9, ??]
-  final class ?? extends NatPTS[??, ??, ??]
-
-  final val _0: _0  = new _0
-  final val _1: _1  = new _1
-  final val _2: _2  = new _2
-  final val _3: _3  = new _3
-  final val _4: _4  = new _4
-  final val _5: _5  = new _5
-  final val _6: _6  = new _6
-  final val _7: _7  = new _7
-  final val _8: _8  = new _8
-  final val _9: _9  = new _9
-  final val ?? : ?? = new ??
-}
-
-// Attempts to use Nat.this.type as refinements of the abstract
-// successor and predecessor types run into compilation time
-// exponential explosion. Timing notes:
-//
-// Largest source alias is _6
-// Largest existential created is _3220.type
-// 3.555 real, 7.164 user, 0.202 sys
-//
-// Largest source alias is _7
-// Largest existential created is _22432.type
-// 6.056 real, 11.557 user, 0.416 sys
-//
-// Largest source alias is _8
-// Largest existential created is _156892.type
-// 20.183 real, 29.146 user, 1.645 sys
-//
-// Largest source alias is _9
-// Largest existential created is _1098088.type
-// 869.508 real, 902.972 user, 16.297 sys

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -37,6 +37,8 @@ object Build extends sbt.Build {
              licenses :=  pspLicenses,
          organization :=  pspOrg,
         scalacOptions ++= scalacOptionsFor(scalaBinaryVersion.value) ++ stdArgs,
+            maxErrors :=  5,
+     triggeredMessage :=  Watched.clearWhenTriggered,
     publishMavenStyle :=  true
   ) ++ (
     if (p.id == "root") Nil

--- a/std/src/main/scala/Gateways.scala
+++ b/std/src/main/scala/Gateways.scala
@@ -166,7 +166,7 @@ trait StdUniversal extends Any with StdUniversal0 { implicit def opsAnyRef[A <: 
 //
 // [error] /mirror/r/psp/std/testOnly/src/test/scala/OperationCounts.scala:56: polymorphic expression cannot be instantiated to expected type;
 // [error]  found   : [CC[X] <: psp.std.Walkable[X]]tc.VC[psp.std.PolicyList[psp.std.Int]]
-// [error]  required: psp.std.api.View[psp.std.Int]
+// [error]  required: psp.std.View[psp.std.Int]
 // [error]     intRange(1, max / 2).m ++ nthRange(max / 2, max).toLinear.m
 // [error]                                                               ^
 // [error] one error found

--- a/std/src/main/scala/HashEq.scala
+++ b/std/src/main/scala/HashEq.scala
@@ -3,7 +3,7 @@ package std
 
 import api._
 
-/** A bad idea in general, but so much less ceremony for limted-use classes.
+/** A bad idea in general, but so much less ceremony for limited-use classes.
  */
 trait NaturalHashEq
 

--- a/std/src/main/scala/package.scala
+++ b/std/src/main/scala/package.scala
@@ -4,7 +4,7 @@ import java.nio.file.Paths
 import java.nio.file.{ attribute => jnfa }
 import scala.{ collection => sc }
 import sc.{ mutable => scm, immutable => sci }
-import psp.std.api._
+import psp.api._
 import psp.std.lowlevel._
 import psp.std.StdShow._
 
@@ -71,7 +71,7 @@ package object std extends psp.std.StdPackage {
   type DocSeq = Each[Doc]
 
   /** Scala, so aggravating.
-   *  [error] could not find implicit value for parameter equiv: psp.std.api.Eq[psp.tests.Pint => psp.std.Boolean]
+   *  [error] could not find implicit value for parameter equiv: psp.api.Eq[psp.tests.Pint => psp.std.Boolean]
    *  The parameter can be given explicitly, it just won't be found unless the function type is invariant.
    *  The same issue arises with intensional sets.
    */


### PR DESCRIPTION
Mirroring psp-dmz (package psp.dmz) I thought it was better that api
be defined in psp.api, as it doesn't have access to anything in the
psp.std package object.

The alternative is that everything in psp-std (the repo/project) is
under psp.std (so psp.std.api, psp.std.dmz, and perhaps psp.std.core),
but this was less change and less breakages for anything outside of
this repo.

Also couple of typos and clearWhenTriggered, threw them in here instead
of as seperate pull-requests.