### PR TITLE
Work around sbt's hostility to easy logging.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -6,6 +6,11 @@ import sbt._, Keys._, psp.libsbt._, Deps._
 import psp.std._
 
 object Build extends sbt.Build {
+  // Assign settings logger here during initialization so it won't be garbage collected.
+  // sbt otherwise will throw an exception if it is used after project loading.
+  private[this] var settingsLogger: Logger = _
+
+  def slog       = settingsLogger
   def commonArgs = wordSeq("-Yno-predef -Yno-adapted-args -unchecked")
   def stdArgs    = "-Yno-imports" +: commonArgs
   def replArgs   = "-language:_" +: commonArgs
@@ -68,6 +73,7 @@ object Build extends sbt.Build {
   }
 
   lazy val root = project.root.setup dependsOn (classpathDeps: _*) settings (
+    initialize := { this.settingsLogger = (sLog in GlobalScope).value ; initialize.value },
     commands ++= Seq(
       aggregateIn(clean, compileOnly),
       aggregateIn(compile in Compile, compileOnly),


### PR DESCRIPTION
I just want to be able to log, must it be so hard? No wonder
everyone uses println. Users of IDEA encounter this:

java.lang.RuntimeException: Settings logger used after project was loaded.
  at scala.sys.package$.error(package.scala:27)
  at sbt.LogManager$$anon$1$$anonfun$slog$1.apply(LogManager.scala:110)
  ...

Here's what I found in the sbt source, around which we now work.

private[sbt] def settingsLogger(state: State): Def.Setting[_] =
  // strict to avoid retaining a reference to `state`
  sLog in GlobalScope :== globalWrapper(state)

// construct a Logger that delegates to the global logger, but only holds a weak reference
//  this is an approximation to the ideal that would invalidate the delegate after loading completes
private[this] def globalWrapper(s: State): Logger = {
  new Logger {
    private[this] val ref = new java.lang.ref.WeakReference(s.globalLogging.full)
    private[this] def slog: Logger = Option(ref.get) getOrElse sys.error("Settings logger used after project was loaded.")

    override val ansiCodesSupported = slog.ansiCodesSupported
    override def trace(t: => Throwable) = slog.trace(t)
    override def success(message: => String) = slog.success(message)
    override def log(level: Level.Value, message: => String) = slog.log(level, message)
  }
}