### PR TITLE
A bit of repl work.

### DIFF
--- a/consoleOnly/src/main/resources/initialCommands.scala
+++ b/consoleOnly/src/main/resources/initialCommands.scala
@@ -1,7 +1,5 @@
 import scala.collection.{ mutable => scm, immutable => sci }
 import java.nio.{ file => jnf }
-import psp._, std._, api._, pio._, jvm._, cache._
+import psp._, std._, api._, pio._, jvm._, cache._, repl._
 import StdEq._, StdShow._
-import psp.std.repl.ReplImport._
-
-def int20  = 1 to 20 map (x => printResult(s"> $x")(x))
+def int20: View[Int] = 1 to 20 tee ("> " + _)

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -109,12 +109,17 @@ object Build extends sbt.Build {
   // A console project which pulls in misc additional dependencies currently being explored.
   // Removing all scalac options except the ones listed here, to eliminate all the warnings
   // repl startup code in resources/initialCommands.scala
-  lazy val consoleOnly = project.helper.usesCompiler.alsoToolsJar dependsOn (testOnly % "test->test") dependsOn (classpathDeps: _*) also (guava, jsr305) settings (
-                    libraryDependencies <+=  scalaCompiler,
-    scalacOptions in (Compile, console)  :=  replArgs,
-       scalacOptions in (Test, console)  :=  replArgs,
-                           key.initRepl <+=  resourceDirectory in Compile mapValue (d => IO.read(d / "initialCommands.scala")),
-                   key.initRepl in Test  +=  "\nimport org.scalacheck._, Prop._, Gen._\nimport psp.tests._"
+  lazy val consoleOnly = (
+    project.helper.usesCompiler.alsoToolsJar
+    dependsOn (testOnly % "test->test")
+    dependsOn (classpathDeps: _*)
+    also (guava, jsr305) settings (
+                      libraryDependencies <+=  scalaCompiler,
+      scalacOptions in (Compile, console)  :=  replArgs,
+         scalacOptions in (Test, console)  :=  replArgs,
+                             key.initRepl <+=  resourceDirectory in Compile mapValue (d => IO.read(d / "initialCommands.scala")),
+                     key.initRepl in Test  +=  "\nimport org.scalacheck._, Prop._, Gen._\nimport psp.tests._"
+    )
   )
 
   def testDependencies = Def setting Seq(

--- a/scalac/src/main/scala/tokens.scala
+++ b/scalac/src/main/scala/tokens.scala
@@ -16,10 +16,10 @@ class TokenAnalysis(val global: Global, val content: Array[Char]) {
     init()
     // scalac helpfully throws errors when trying to compile itself.
     // "macro is now a reserved word; usage as an identifier is disallowed"
-    def deprecationWarning(off: Int, msg: String): Unit   = echoErr(s"deprecationWarning($off, $msg)")
-    def error  (off: Int, msg: String): Unit              = echoErr(s"error($off, $msg)")
-    def incompleteInputError(off: Int, msg: String): Unit = echoErr(s"incompleteInputError($off, $msg)")
-    def warning(off: Int, msg: String): Unit              = echoErr(s"warning($off, $msg)") // 2.10 only
+    def deprecationWarning(off: Int, msg: String): Unit   = echoErr(s"deprecationWarning($off, $msg)".s)
+    def error  (off: Int, msg: String): Unit              = echoErr(s"error($off, $msg)".s)
+    def incompleteInputError(off: Int, msg: String): Unit = echoErr(s"incompleteInputError($off, $msg)".s)
+    def warning(off: Int, msg: String): Unit              = echoErr(s"warning($off, $msg)".s) // 2.10 only
   }
 
   private def tokenize(): Direct[Token] = {

--- a/std/src/main/scala/PspStringOps.scala
+++ b/std/src/main/scala/PspStringOps.scala
@@ -21,8 +21,10 @@ object Extract {
  */
 final class PspStringOps(val self: String) extends AnyVal with ForceShowDirect {
   def render: String = self // XXX
+
   def r: Regex = Regex(self)
   def u: jUrl  = jUrl(self)
+  def s: Shown = Shown(self)
 
   private def unwrapArg(arg: Any): AnyRef = arg match {
     case x: ScalaNumber => x.underlying

--- a/std/src/main/scala/ViewOps.scala
+++ b/std/src/main/scala/ViewOps.scala
@@ -36,6 +36,8 @@ trait ApiViewOps[+A] extends Any {
   def zfoldl[B](f: (B, A) => B)(implicit z: Empty[B]): B = foldl(z.empty)(f)
   def zfoldr[B](f: (A, B) => B)(implicit z: Empty[B]): B = foldr(z.empty)(f)
 
+  def tee(f: A => Shown): View[A] = xs map (_ doto (x => echoOut(f(x))))
+
   /** Not especially efficient while we're sorting this out.
    *                                       sorting this out.
    *                                       sorting         .

--- a/std/src/main/scala/package.scala
+++ b/std/src/main/scala/package.scala
@@ -85,7 +85,6 @@ package object std extends psp.std.StdPackage with psp.impl.CreateBy {
   def assert(assertion: => Boolean)(implicit z: Assertions): Unit                          = Assertions.using(z)(assertion, "assertion failed")
   def assert(assertion: => Boolean, msg: => Any)(implicit z: Assertions): Unit             = Assertions.using(z)(assertion, s"assertion failed: $msg")
   def asserting[A](x: A)(assertion: => Boolean, msg: => String)(implicit z: Assertions): A = x sideEffect assert(assertion, msg)
-  def echoErr[A: TryShow](x: A): Unit                                                      = Console echoErr pp"$x"
   def printResult[A: TryShow](msg: String)(result: A): A                                   = result doto (r => println(pp"$msg: $r"))
   def printResultIf[A: TryShow : Eq](show: A, msg: String)(result: A): A                   = result doto (r => if (r === show) println(pp"$msg: $r"))
   def print[A: TryShow](x: A): Unit                                                        = Console putOut pp"$x"
@@ -93,6 +92,9 @@ package object std extends psp.std.StdPackage with psp.impl.CreateBy {
   def require(requirement: Boolean): Unit                                                  = if (!requirement) illegalArgumentException("requirement failed")
   def require(requirement: Boolean, msg: => Any): Unit                                     = if (!requirement) illegalArgumentException(s"requirement failed: $msg")
   def showResult[A: TryShow](msg: String)(result: A): A                                    = result doto (r => println(pp"$msg: $r"))
+
+  def echoErr(x: Shown): Unit = Console echoErr x.to_s
+  def echoOut(x: Shown): Unit = Console echoOut x.to_s
 
   // Operations involving classes, classpaths, and classloaders.
   def classLoaderOf[A: CTag](): ClassLoader = classOf[A].getClassLoader

--- a/std/src/main/scala/repl.scala
+++ b/std/src/main/scala/repl.scala
@@ -1,8 +1,7 @@
 package psp
 package std
-package repl
 
-import api._
+import std._, api._
 import StdShow._
 
 trait TargetCommon[A] {
@@ -11,30 +10,22 @@ trait TargetCommon[A] {
   def >>(implicit z: TryShow[A]): Direct[A] = target doto (_ mapNow z.show foreach println)
   def !>(implicit z: Show[A]): Direct[A]    = target doto (xs => (xs mapNow z.show).sorted foreach println)
 }
-
-trait ReplImportLow {
+trait ReplPackageLow {
   implicit final class ReplOps[A](val target: A) {
     def >(implicit z: Show[A]): A     = target doto (x => println(z show x))
     def >>(implicit z: TryShow[A]): A = target doto (x => println(z show x))
   }
-  implicit final class ReplJavaOps[A](val xs: jCollection[A])        extends TargetCommon[A] { def target = xs.m.toDirect }
+  implicit final class ReplJavaOps[A](val xs: jCollection[A])        extends TargetCommon[A] { def target = xs.toDirect }
 }
-object ReplImport extends ReplImportLow {
-  implicit final class ReplForeachOps[A](val xs: Each[A])            extends TargetCommon[A] { def target = xs.m.toDirect }
-  implicit final class ReplArrayOps[A](val xs: Array[A])             extends TargetCommon[A] { def target = xs.m.toDirect }
-  implicit final class ReplTraversableOps[A](val xs: sCollection[A]) extends TargetCommon[A] { def target = xs.m.toDirect }
+
+package object repl extends ReplPackageLow {
+  implicit final class ReplForeachOps[A](val xs: Each[A])            extends TargetCommon[A] { def target = xs.toDirect }
+  implicit final class ReplArrayOps[A](val xs: Array[A])             extends TargetCommon[A] { def target = xs.toDirect }
+  implicit final class ReplTraversableOps[A](val xs: sCollection[A]) extends TargetCommon[A] { def target = xs.toDirect }
 
   implicit final class ReplMapOps[K, V](val target: ExMap[K, V]) {
     def >(implicit z1: Show[K], z2: Show[V]): ExMap[K, V]        = target doto (m => println(show"$m"))
     def >>(implicit z1: TryShow[K], z2: TryShow[V]): ExMap[K, V] = target doto (m => println(pp"$m"))
     def !>(implicit z1: Show[K], z2: Show[V]): ExMap[K, V]       = target doto (m => m !>)
-  }
-}
-
-object show {
-  def apply(arg: TryShown, maxElements: Int): String = {
-    val s = arg.try_s
-    val nl = if (s contains "\n") "\n" else ""
-    nl + s + "\n"
   }
 }


### PR DESCRIPTION
Introduced view method tee, which acts something like command
line tee. It's handy for investigating whether views are doing
anything like they ought to be doing. For instance, here's
what this expression currently prints, which looks suboptimal.
int20 is defined in initialCommands as

  def int20: View[Int] = 1 to 20 tee ("> " + _)

// Can't see why this should have to print more than five.
scala> int20 dropWhile (_ < 3) take 3.size reducel (_ + _)
> 1
> 2
> 3
> 1
> 2
> 3
> 1
> 2
> 3
> 4
> 5
res1: Int = 12