### PR TITLE
Recovered test coverage.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ cache:
   directories:
     - $HOME/.ivy2/cache
     - $HOME/.sbt
+    - $HOME/.cache/pip
 
 language: scala
 script: project/bin/run-travis
@@ -15,5 +16,5 @@ jdk:
 scala: 2.11.7
 
 # codecov
-# before_install: pip install --user codecov
-# after_success: codecov
+before_install: pip install --user codecov
+after_success: codecov

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 psp.std - a non-standard library
 ================================
 
-[![Join the chat at https://gitter.im/paulp/psp-std](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/paulp/psp-std?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-
-[![Build Status](https://travis-ci.org/paulp/psp-std.svg?branch=master)](https://travis-ci.org/paulp/psp-std)
+[![Build Status](https://travis-ci.org/paulp/psp-std.svg?branch=master)](https://travis-ci.org/paulp/psp-std) [![Code Coverage](http://codecov.io/github/paulp/psp-std/coverage.svg?branch=master)](http://codecov.io/github/paulp/psp-std?branch=master) [![Join the chat at https://gitter.im/paulp/psp-std](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/paulp/psp-std?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 ### Background
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -5,6 +5,7 @@ import scala.Predef.{ conforms => _ }
 import sbt._, Keys._, psp.libsbt._, Deps._
 import psp.std._
 import com.typesafe.sbt.JavaVersionCheckPlugin.autoImport._
+import scoverage.ScoverageKeys._
 
 object Build extends sbt.Build {
   def consoleDependencies = List(jsr305, ammonite)
@@ -85,9 +86,12 @@ object Build extends sbt.Build {
       aggregateIn(compile in Compile, compileOnly),
       aggregateIn(test, testOnly),
       aggregateIn(key.packageTask, publishOnly),
+      aggregateIn(coverageReport, compileOnly),
+      aggregateIn(coverageAggregate, compileOnly),
       aggregateIn(publish, publishOnly),
       aggregateIn(publishLocal, publishOnly),
-      aggregateIn(publishM2, publishOnly)
+      aggregateIn(publishM2, publishOnly),
+      Command.command("cov")(_ justRun (coverageAggregate in compileOnly))
     ),
     console in Compile <<=  console in Compile in consoleOnly,
        console in Test <<=  console in Test in consoleOnly,

--- a/project/bin/run-travis
+++ b/project/bin/run-travis
@@ -4,12 +4,14 @@
 uname="$(uname -a)"
 
 runTests () {
-  sbt -J-Xmx3784m clean test || exit 1
+  sbt -J-Xmx3784m clean coverage test || exit 1
   echo "[info] $(date) - finished sbt test"
+  sbt coverageReport
 
   # Tricks to avoid unnecessary cache updates
-  find $HOME/.sbt -name "*.lock" -delete
-  find $HOME/.ivy2 -name "ivydata-*.properties" -delete
+  find "$HOME/.sbt" -name "*.lock" -print -delete
+  find "$HOME/.ivy2" -name "ivydata-*.properties" -print -delete
+  exit 0
 }
 
 stripTerminalEscapeCodes () {

--- a/project/consoleOnly/src/main/scala/ammonite.scala
+++ b/project/consoleOnly/src/main/scala/ammonite.scala
@@ -18,8 +18,12 @@ object REPL extends Repl(System.in, System.out, Ref(Storage(Repl.defaultAmmonite
 
   // Working around ammonite bugs.
   // https://github.com/lihaoyi/Ammonite/issues/213
-  private def mkNames(name: String) = s"""type $name[-A] = psp.api.$name[A] ; val $name = psp.std.$name"""
-  private def workarounds           = vec("Order", "Eq", "Show", "Empty") map mkNames mk_s "\n"
+  private def mkNames(name: String, variance: String): String =
+    s"""type $name[${variance}A] = psp.api.$name[A] ; val $name = psp.std.$name"""
+
+  private def cov         = vec("Order", "Eq", "Show") map (mkNames(_, "-"))
+  private def inv         = vec("Empty") map (mkNames(_, ""))
+  private def workarounds = cov ++ inv joinLines
 
   def start(): Unit = {
     compiler.settings processArgumentString options

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.3")

--- a/std/src/main/scala/ApiExtensions.scala
+++ b/std/src/main/scala/ApiExtensions.scala
@@ -211,8 +211,8 @@ final class FunOps[A, B](val f: Fun[A, B]) extends AnyVal {
   }
 
   def traced(in: A => Unit, out: B => Unit): Fun[A, B] = ( f
-     mapIn[A] { x => in(x) ; x }
-    mapOut[B] { x => out(x) ; x }
+    .   mapIn[A] { x => in(x) ; x }
+    .  mapOut[B] { x => out(x) ; x }
   )
   def memoized: Fun[A, B] = {
     val cache = scala.collection.mutable.Map[A, B]()


### PR DESCRIPTION
Here's the syntax which crashes the compiler during coverage:

  `f map[A] (5)`

Notice no dot.

Also, further sickness in the world of ammonite bug workarounds.