### PR TITLE
Fix incremental compilation.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -62,6 +62,7 @@ object Build extends sbt.Build {
                             organization :=  pspOrg,
                            scalacOptions ++= scalacOptionsFor(scalaBinaryVersion.value) ++ stdArgs,
                         triggeredMessage :=  Watched.clearWhenTriggered,
+                              incOptions ~=  (_ withNameHashing false),
    javaVersionPrefix in javaVersionCheck :=  Some("1.8")
   ) ++ ( if (p.id == "root") Nil else Seq(target <<= javaCrossTarget(p.id)) )
 


### PR DESCRIPTION
Add some whitespace to Implicits.scala to induce recompilation
of only that file by sbt and witness this explosion of unhappiness:

[info] Compiling 1 Scala source to /g/psp-std/target/std/java_1.8/scala-2.11/classes...
[error] missing or invalid dependency detected while loading class file 'StdPackageObject.class'.
[error] Could not access type EmptyInstances in package psp.std,
[error] because it (or its dependencies) are missing. Check your build definition for
[error] missing or conflicting dependencies. (Re-run with `-Ylog-classpath` to see the problematic classpath.)
[error] A full rebuild may help if 'StdPackageObject.class' was compiled against an incompatible version of psp.std.
[error] missing or invalid dependency detected while loading class file 'StdPackageObject.class'.
[error] Could not access type PrimitiveInstances in package psp.std,
[error] because it (or its dependencies) are missing. Check your build definition for
[error] missing or conflicting dependencies. (Re-run with `-Ylog-classpath` to see the problematic classpath.)
[error] A full rebuild may help if 'StdPackageObject.class' was compiled against an incompatible version of psp.std.
[error] missing or invalid dependency detected while loading class file 'StdPackageObject.class'.
[error] Could not access type AlgebraInstances in package psp.std,
[error] because it (or its dependencies) are missing. Check your build definition for
[error] missing or conflicting dependencies. (Re-run with `-Ylog-classpath` to see the problematic classpath.)
[error] A full rebuild may help if 'StdPackageObject.class' was compiled against an incompatible version of psp.std.
[error] missing or invalid dependency detected while loading class file 'StdPackageObject.class'.
[error] Could not access type StdImplicits in package psp.std,
[error] because it (or its dependencies) are missing. Check your build definition for
[error] missing or conflicting dependencies. (Re-run with `-Ylog-classpath` to see the problematic classpath.)
[error] A full rebuild may help if 'StdPackageObject.class' was compiled against an incompatible version of psp.std.
[error] four errors found

NOT ANY MORE. Disabling name hashing fixes it.