### PR TITLE
Cleanup the sources in api some

### DIFF
--- a/api/src/main/java/psp/api/Cmp.java
+++ b/api/src/main/java/psp/api/Cmp.java
@@ -3,8 +3,8 @@ package psp.api;
 public enum Cmp {
   LT(-1), EQ(0), GT(1);
 
-  private int intValue;
-  private Cmp(int intValue) { this.intValue = intValue; }
+  private final int intValue;
+  private Cmp(final int intValue) { this.intValue = intValue; }
   public int intValue() { return intValue; }
   public Cmp flip() {
     if (intValue < 0) return GT;

--- a/api/src/main/scala/ADTs.scala
+++ b/api/src/main/scala/ADTs.scala
@@ -6,9 +6,9 @@ package api
 import Api._
 
 /** The Size hierarchy is:
- *                   Size
+ *                     Size
  *                  /        \
- *               Atomic      Bounded
+ *               Atomic     Bounded
  *              /      \
  *          Infinite  Precise
  *
@@ -25,18 +25,17 @@ import Api._
 sealed trait Size extends Any
 sealed trait Atomic extends Any with Size
 final case object Infinite extends Atomic
-final case class Bounded private[api] (lo: Precise, hi: Atomic) extends Size
 final class Precise private[api] (val get: Long) extends AnyVal with Atomic {
   def +(n: Long): Precise = Size(get + n)
   def -(n: Long): Precise = Size(get - n)
   def getInt: Int         = get.toInt
   override def toString   = s"$get"
 }
+final case class Bounded private[api] (lo: Precise, hi: Atomic) extends Size
 
 final class SizeExtractor(val get: Long) extends AnyVal with Opt[Long] { def isEmpty = get < 0 }
 
 object Finite extends (Long => Precise) {
-
   def apply(n: Long): Precise            = new Precise( if (n < 0) 0 else n )
   def unapply(n: Precise): SizeExtractor = new SizeExtractor(n.get)
 

--- a/api/src/main/scala/Interfaces.scala
+++ b/api/src/main/scala/Interfaces.scala
@@ -3,32 +3,32 @@ package api
 
 import Api._
 
-trait IndexOrNth extends Any with Opt[Long]
-trait Index extends Any with IndexOrNth
-trait Nth extends Any with IndexOrNth
-
 /** Name-based extractor methods. These interfaces aren't necessary
  *  for it (thus "name-based") but provide helpful structure when used.
  */
 trait IsEmpty extends Any              { def isEmpty: Boolean }
 trait Opt[+A] extends Any with IsEmpty { def get: A           }
 
-trait Each[@fspec +A]    extends Any with Foreach[A] with NotView        { def foreach(f: A => Unit): Unit   }
-trait Indexed[@fspec +A] extends Any with Each[A]                        { def elemAt(i: Index): A           }
-trait Direct[@fspec +A]  extends Any with Indexed[A]                     { def size: Precise                 }
-trait Linear[@fspec +A]  extends Any with Each[A]    with IsEmpty        { def head: A ; def tail: Linear[A] }
+sealed trait IndexOrNth extends Any with Opt[Long]
+trait Index             extends Any with IndexOrNth
+trait Nth               extends Any with IndexOrNth
 
-trait ExSet[A]      extends Any with Each[A] { def apply(x: A): Boolean    }
-trait ExMap[K, +V]  extends Any              { def lookup: FiniteDom[K, V] }
+sealed trait MaybeView extends Any                { def isView: Boolean      }
+trait IsView           extends Any with MaybeView { final def isView = true  }
+trait NotView          extends Any with MaybeView { final def isView = false }
 
 trait Foreach[+A] extends Any {
   def size: Size
   def foreach(f: A => Unit): Unit
 }
 
-sealed trait MaybeView extends Any                { def isView: Boolean      }
-trait IsView           extends Any with MaybeView { final def isView = true  }
-trait NotView          extends Any with MaybeView { final def isView = false }
+trait Each[@fspec +A]    extends Any with Foreach[A] with NotView
+trait Indexed[@fspec +A] extends Any with Each[A]                 { def elemAt(i: Index): A           }
+trait Direct[@fspec +A]  extends Any with Indexed[A]              { def size: Precise                 }
+trait Linear[@fspec +A]  extends Any with Each[A]    with IsEmpty { def head: A ; def tail: Linear[A] }
+
+trait ExSet[A]     extends Any with Each[A] { def apply(x: A): Boolean    }
+trait ExMap[K, +V] extends Any              { def lookup: FiniteDom[K, V] }
 
 trait View[@fspec +A] extends Any with Foreach[A] with IsView {
   def force[That](implicit z: Builds[A, That]): That

--- a/api/src/main/scala/PspApi.scala
+++ b/api/src/main/scala/PspApi.scala
@@ -34,15 +34,14 @@ trait PspApi extends ExternalLibs {
 
   // A few methods it is convenient to expose at this level.
   def ?[A](implicit value: A): A               = value
-  def abort(msg: String): Nothing              = throw new java.lang.RuntimeException(msg)
+  def abort(msg: String): Nothing              = runtimeException(msg)
   def doto[A](x: A)(f: A => Unit): A           = sideEffect(x, f(x))
   def emptyValue[A](implicit z: Empty[A]): A   = z.empty
   def identity[A](x: A): A                     = x
-  def implicitly[A](implicit x: A): A          = x
   def none[A](): Option[A]                     = scala.None
   def show[A](implicit z: Show[A]): Show[A]    = z
-  def some[A](x: A): Some[A]                   = scala.Some(x)
   def sideEffect[A](result: A, exprs: Any*): A = result
+  def some[A](x: A): Some[A]                   = scala.Some(x)
 
   def newArray[A: CTag](length: Int): Array[A] = new Array[A](length)
   def copyArray[A: CTag](src: Array[A]): Array[A] = {

--- a/api/src/main/scala/TypeClasses.scala
+++ b/api/src/main/scala/TypeClasses.scala
@@ -59,13 +59,13 @@ object Pair {
 
   object Cleave {
     def apply[R, A, B](f: (A, B) => R, l: R => A, r: R => B): Cleave[R, A, B] = new Cleave[R, A, B] {
-      def split(x: R): A -> B = ((l(x), r(x)))
+      def split(x: R): A -> B = (l(x), r(x))
       def join(x: A, y: B): R = f(x, y)
     }
   }
   object Split {
     def apply[R, A, B](l: R => A, r: R => B): Split[R, A, B] =
-      new Split[R, A, B] { def split(x: R): A -> B = ((l(x), r(x))) }
+      new Split[R, A, B] { def split(x: R): A -> B = (l(x), r(x)) }
   }
   object Join {
     def apply[R, A, B](f: (A, B) => R): Join[R, A, B] =

--- a/api/src/main/scala/ext/JavaLib.scala
+++ b/api/src/main/scala/ext/JavaLib.scala
@@ -1,7 +1,7 @@
 package psp
 package ext
 
-import scala.{ Any, Nothing, Long, Unit, StringContext }
+import scala.{ Any, Long, Nothing, StringContext, Unit }
 import scala.annotation.unchecked.{ uncheckedVariance => uV }
 import java.{ lang => jl }
 import java.{ util => ju }

--- a/api/src/main/scala/ext/ScalaLib.scala
+++ b/api/src/main/scala/ext/ScalaLib.scala
@@ -23,8 +23,6 @@ import sc.{ mutable => scm, immutable => sci }
  *   - DelayedInit is very special but it's garbage so omitted
  */
 trait ScalaLib {
-  self: ExternalLibs =>
-
   // The top and bottom types.
   type Any     = scala.Any
   type AnyRef  = scala.AnyRef
@@ -73,6 +71,7 @@ trait ScalaLib {
   type scSeq[+A]              = sc.Seq[A]
   type scSet[A]               = sc.Set[A]
   type scTraversable[+A]      = sc.Traversable[A]
+
   type sciIndexedSeq[+A]      = sci.IndexedSeq[A]
   type sciList[+A]            = sci.List[A]
   type sciMap[K, +V]          = sci.Map[K, V]
@@ -80,6 +79,7 @@ trait ScalaLib {
   type sciSet[A]              = sci.Set[A]
   type sciStream[+A]          = sci.Stream[A]
   type sciVector[+A]          = sci.Vector[A]
+
   type scmBuilder[-Elem, +To] = scm.Builder[Elem, To]
   type scmMap[K, V]           = scm.Map[K, V]
 

--- a/std/src/main/scala/StdPackage.scala
+++ b/std/src/main/scala/StdPackage.scala
@@ -90,7 +90,7 @@ abstract class StdPackageObject extends scala.AnyRef
   def ??? : Nothing = throw new scala.NotImplementedError
 
   def classOf[A: CTag](): Class[_ <: A]      = classTag[A].runtimeClass.castTo[Class[_ <: A]]
-  def classTag[A: CTag] : CTag[A]            = implicitly[CTag[A]]
+  def classTag[A: CTag] : CTag[A]            = ?[CTag[A]]
   def classFilter[A: CTag] : Partial[Any, A] = Partial(_.isClass[A], _.castTo[A])
 
   def transitiveClosure[A: Eq](root: A)(expand: A => Foreach[A]): View[A] = inView { f =>


### PR DESCRIPTION
Changes include:
* make IndexOrNth sealed
* make things final in Cmp
* align Size ascii art
* order interfaces so they read in as a sequential narrative (without using anything that's defined later)
* drop implicitly in favour of ?
* drop the unneeded self type in ScalaLib
* alphabetically sorting