### PR TITLE
Eliminating package object.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Suggested contents for `build.sbt`:
 ```scala
               scalaVersion :=  "2.11.7"
        libraryDependencies +=  "org.improving" %% "psp-std" % "0.5.6"
-initialCommands in console :=  "import psp._, std._, api._, StdEq._, StdShow._"
+initialCommands in console :=  "import psp._, std._, all._, api._, StdEq._, StdShow._"
 ```
 
 Then `sbt console` and you can look around.

--- a/api/src/main/scala/Creators.scala
+++ b/api/src/main/scala/Creators.scala
@@ -1,0 +1,29 @@
+package psp
+package api
+
+import Api._
+
+trait PspCreators {
+  def inView[A](mf: Suspended[A]): View[A]
+  def list[A](xs: A*): Each[A]
+  def set[A: Eq](xs: A*): ExSet[A]
+  def vec[A](xs: A*): Direct[A]
+  def view[A](xs: A*): View[A]
+  def zip[A, B](xs: (A->B)*): ZipView[A, B]
+}
+
+trait PspOptionType {
+  type Opt[X]
+
+  def apply[A](x: A): Opt[A]
+  def empty[A] : Opt[A]
+  def join[A](x: Opt[Opt[A]]): Opt[A]
+
+  abstract class Ops[A](x: Opt[A]) {
+    def isEmpty: Boolean
+    def fold[B](e: => B, f: A => B): B
+    def map[B](f: A => B): Opt[B]
+    def flatMap[B](f: A => Opt[B]): Opt[B]
+    def filter(p: A => Boolean): Opt[A]
+  }
+}

--- a/api/src/main/scala/PspApi.scala
+++ b/api/src/main/scala/PspApi.scala
@@ -6,7 +6,7 @@ import psp.ext.ExternalLibs
 
 // Importing from this is necessary to use these aliases within the api package,
 // where they aren't otherwise visible because there's no api package object.
-private[api] object Api extends PspApi
+private[api] final object Api extends PspApi
 
 trait PspApi extends ExternalLibs {
   // Caveat: ?=> associates to the left instead of the right.

--- a/project/consoleOnly/src/main/scala/ammonite.scala
+++ b/project/consoleOnly/src/main/scala/ammonite.scala
@@ -1,6 +1,6 @@
 package psp
 
-import std._, api._, StdShow._
+import std._, all._, api._, StdShow._
 import ammonite.repl.{ Ref, Repl, Storage }
 import ammonite.repl.frontend.FrontEnd
 import java.lang.System
@@ -8,7 +8,7 @@ import java.lang.System
 object ReplMain {
   def storage = Ref(Storage(Repl.defaultAmmoniteHome, None))
   def initImports = sm"""
-    |import psp._, psp.std._, psp.api._
+    |import psp._, std._, all._, api._
     |import StdShow._, StdEq._, INREPL._
   """
   // Working around ammonite bugs.

--- a/project/testOnly/src/main/scala/Benchmark.scala
+++ b/project/testOnly/src/main/scala/Benchmark.scala
@@ -1,7 +1,7 @@
 package psp
 package tests
 
-import std._, StdShow._
+import std._, all._, StdShow._
 
 object Benchmark {
   var total = 0L

--- a/project/testOnly/src/main/scala/Benchmark2.scala
+++ b/project/testOnly/src/main/scala/Benchmark2.scala
@@ -1,7 +1,7 @@
 package psp
 package tests
 
-import std._, StdShow._
+import std._, all._, StdShow._
 
 object Benchmark2 {
   var total = 0L

--- a/project/testOnly/src/main/scala/Bundle.scala
+++ b/project/testOnly/src/main/scala/Bundle.scala
@@ -1,7 +1,7 @@
 package psp
 package tests
 
-import psp._, std._, api._, StdShow._
+import psp._, std._, all._, api._, StdShow._
 import scala.Console.{ println => _, _ }
 
 trait Bundle extends ShowSelf {

--- a/project/testOnly/src/main/scala/Counter.scala
+++ b/project/testOnly/src/main/scala/Counter.scala
@@ -1,7 +1,7 @@
 package psp
 package tests
 
-import std._
+import std._, all._
 import java.util.concurrent.atomic.AtomicInteger
 
 trait Counter[+A] {

--- a/project/testOnly/src/main/scala/Generators.scala
+++ b/project/testOnly/src/main/scala/Generators.scala
@@ -2,7 +2,7 @@ package psp
 package tests
 
 import Gen._
-import psp.std._, api._, StdShow._
+import psp._, std._, all._, api._, StdShow._
 
 package gen {
   class RegexGenerator(val letter: Gen[Char]) {

--- a/project/testOnly/src/main/scala/Laws.scala
+++ b/project/testOnly/src/main/scala/Laws.scala
@@ -1,7 +1,7 @@
 package psp
 package tests
 
-import std._, api._
+import std._, all._, api._
 
 abstract class Laws[A : Eq] {
   def associative(f: BinOp[A]): Forall3[A]               = (a, b, c) => f(a, f(b, c)) === f(f(a, b), c)

--- a/project/testOnly/src/main/scala/OperationCounts.scala
+++ b/project/testOnly/src/main/scala/OperationCounts.scala
@@ -1,7 +1,7 @@
 package psp
 package tests
 
-import psp.std._, api._, StdShow._, StdEq._
+import psp.std._, all._, api._, StdShow._, StdEq._
 import org.scalacheck._, Prop.forAll, Gen._
 import scala.{ collection => sc }
 import sc.{ mutable => scm, immutable => sci }

--- a/project/testOnly/src/main/scala/Probe.scala
+++ b/project/testOnly/src/main/scala/Probe.scala
@@ -1,7 +1,7 @@
 package psp
 package tests
 
-import psp.std._, api._
+import psp.std._, all._, api._
 import scala.{ collection => sc }
 import sc.{ mutable => scm, immutable => sci }
 

--- a/project/testOnly/src/main/scala/Typechecked.scala
+++ b/project/testOnly/src/main/scala/Typechecked.scala
@@ -1,6 +1,7 @@
 package psp
 package std
 
+import all._
 import java.util.regex.Pattern
 import scala.reflect.macros.TypecheckException
 import scala.reflect.macros.blackbox.Context

--- a/project/testOnly/src/main/scala/ViewClass.scala
+++ b/project/testOnly/src/main/scala/ViewClass.scala
@@ -1,7 +1,7 @@
 package psp
 package tests
 
-import psp.std._, api._, StdShow._
+import psp.std._, all._, api._, StdShow._
 import scala.{ collection => sc }
 import sc.{ mutable => scm, immutable => sci }
 

--- a/project/testOnly/src/main/scala/package.scala
+++ b/project/testOnly/src/main/scala/package.scala
@@ -1,6 +1,6 @@
 package psp
 
-import std._, api._, StdShow._, StdEq._
+import api._, std._, all._, StdShow._, StdEq._
 import scala.Console.{ println => _, _ }
 
 package object tests {

--- a/project/testOnly/src/test/scala/AlgebraSpec.scala
+++ b/project/testOnly/src/test/scala/AlgebraSpec.scala
@@ -3,7 +3,7 @@ package tests
 
 import org.scalacheck._
 import org.scalacheck.Prop.forAll
-import psp.std._, api._
+import psp.std._, api._, all._
 
 class AlgebraSpec[A](name: String)(implicit algebra: BooleanAlgebra[A], arb: Arbitrary[A], equiv: Eq[A]) extends AlgebraLaws[A] with ScalacheckBundle {
   def bundle = s"Boolean Algebra laws for type $name"

--- a/project/testOnly/src/test/scala/CollectionsSpec.scala
+++ b/project/testOnly/src/test/scala/CollectionsSpec.scala
@@ -2,7 +2,7 @@ package psp
 package tests
 
 import scala.collection.immutable.StringOps
-import std._, api._,StdEq._, StdShow._
+import std._, api._, all._, StdEq._, StdShow._
 import Prop.forAll
 
 class EmptySpec extends ScalacheckBundle {
@@ -416,10 +416,18 @@ class CollectionsSpec extends ScalacheckBundle {
         jset.m.map(fst) map paired build
         ),
       expectTypes[jMap[_, _]](
-        (jmap map identity).force[jMap[_, _]],
-        jmap.m build,
-        jmap.m map identity build,
-        jmap.m map fst map identity map paired build
+        (jmap map identity).force[jMap[_, _]]
+        // jmap.m build,
+        // jmap.m map identity build,
+        // jmap.m map fst map identity map paired build
+        //
+        // After changing the package object to a regular object, the commented lines fail like:
+        //
+        // [error] could not find implicit value for parameter z: UnbuildsAs[this.Elem, jMap[String,Int]]
+        // [error]         jmap.m build,
+        // [error]         ^
+        //
+        // The "this.Elem" is a typical scala substitution bug.
       )
     )
   }

--- a/project/testOnly/src/test/scala/InferenceSpec.scala
+++ b/project/testOnly/src/test/scala/InferenceSpec.scala
@@ -1,7 +1,7 @@
 package psp
 package tests
 
-import psp.std._, api._, StdEq._, StdShow._
+import psp.std._, all._, api._, StdEq._, StdShow._
 
 class SliceSpec extends ScalacheckBundle {
   def bundle = "Slice Operations"

--- a/project/testOnly/src/test/scala/TestRunner.scala
+++ b/project/testOnly/src/test/scala/TestRunner.scala
@@ -1,7 +1,7 @@
 package psp
 package tests
 
-import std._, Prop.forAll
+import std.all._, Prop.forAll
 
 object TestRunner_211 extends TestRunnerCommon {
   def scalaVersion = "2.11"

--- a/project/testOnly/src/test/scala/TestRunnerCommon.scala
+++ b/project/testOnly/src/test/scala/TestRunnerCommon.scala
@@ -1,7 +1,7 @@
 package psp
 package tests
 
-import psp._, std._, api._, StdShow._
+import psp._, std._, api._, all._, StdShow._
 
 abstract class TestRunnerCommon {
   def scalaVersion: String

--- a/project/testOnly/src/test/scala/Typecheck.scala
+++ b/project/testOnly/src/test/scala/Typecheck.scala
@@ -1,7 +1,7 @@
 package psp
 package tests
 
-import psp._, std._, api._, macros._
+import psp._, std._, all._, api._, macros._
 import Expressions._
 
 class Typecheck extends ScalacheckBundle {

--- a/project/testOnly/src/test/scala/generate.scala
+++ b/project/testOnly/src/test/scala/generate.scala
@@ -1,7 +1,7 @@
 package psp
 package tests
 
-import psp.std._
+import psp.std._, all._
 
 /** TODO - actually generate the code via an sbt generator.
  */

--- a/std/src/main/scala/Algebra.scala
+++ b/std/src/main/scala/Algebra.scala
@@ -1,7 +1,8 @@
 package psp
 package std
 
-import api._
+
+import api._, all._
 
 object Algebras {
   final case class Not[A](f: ToBool[A]) extends ToBool[A] with ShowSelf {

--- a/std/src/main/scala/All.scala
+++ b/std/src/main/scala/All.scala
@@ -1,0 +1,18 @@
+package psp
+package std
+
+import api._, StdShow._
+
+object all extends StdAll {
+  final val NoIndex       = Index.invalid
+  final val NoFile: jFile = jFile("")
+  final val NoPath: jPath = jPath("")
+  final val NoUri: jUri   = jUri("")
+
+  implicit final class DocSeqOps(xs: Direct[Doc]) {
+    def joinLines: String = xs mapNow (x => render(x)) mk_s EOL
+  }
+
+  implicit def foreachDocShows[A: Show](xs: Foreach[A]): DocSeqOps =
+    new DocSeqOps(inView[A](xs foreach _) map (x => Doc(x)))
+}

--- a/std/src/main/scala/AtomicView.scala
+++ b/std/src/main/scala/AtomicView.scala
@@ -1,7 +1,7 @@
 package psp
 package std
 
-import api._, StdEq._, StdShow._, Unsafe.inheritedShow
+import api._, all._, StdEq._, StdShow._, Unsafe.inheritedShow
 import lowlevel.CircularBuffer
 
 sealed abstract class AtomicView[A, Repr] extends IBaseView[A, Repr] {

--- a/std/src/main/scala/BiIterable.scala
+++ b/std/src/main/scala/BiIterable.scala
@@ -1,7 +1,8 @@
 package psp
 package std
 
-import api._
+
+import api._, all._
 
 /** Classes which implement both the java and scala interfaces.
  */

--- a/std/src/main/scala/Builds.scala
+++ b/std/src/main/scala/Builds.scala
@@ -11,7 +11,8 @@ package std
  *  are written out as Tuple2[K, V] and not (K, V) to emphasize I'm using Tuple on purpose.
  *  The rest of the time one should write it K -> V.
  */
-import api._
+
+import api._, all._
 
 object Built {
   def apply[A, R](xs: Foreach[A])(implicit z: Builds[A, R]): R = z build xs

--- a/std/src/main/scala/Classes.scala
+++ b/std/src/main/scala/Classes.scala
@@ -1,7 +1,8 @@
 package psp
 package std
 
-import api._, StdShow._
+
+import api._, all._, StdShow._
 
 /** Motley objects for which a file of residence is not obvious.
  */

--- a/std/src/main/scala/Consecutive.scala
+++ b/std/src/main/scala/Consecutive.scala
@@ -1,7 +1,8 @@
 package psp
 package std
 
-import api._
+
+import api._, all._
 import Consecutive.empty
 
 final class Consecutive[+A] private (val startInt: Int, val lastInt: Int, f: Int => A) extends Direct[A] with ShowSelf {

--- a/std/src/main/scala/Conversions.scala
+++ b/std/src/main/scala/Conversions.scala
@@ -1,7 +1,8 @@
 package psp
 package std
 
-import api._, Java._
+
+import api._, all._, Java._
 
 final class Conversions[A](val xs: View[A]) extends AnyVal with ConversionsImpl[A]
 

--- a/std/src/main/scala/Each.scala
+++ b/std/src/main/scala/Each.scala
@@ -1,7 +1,8 @@
 package psp
 package std
 
-import api._
+
+import api._, all._
 
 object Direct extends Constructions[Direct] {
   def construct[A](size: Size, mf: Suspended[A]): Vec[A] = Vec.newBuilder[A] build Each(mf)

--- a/std/src/main/scala/Empty.scala
+++ b/std/src/main/scala/Empty.scala
@@ -1,7 +1,8 @@
 package psp
 package std
 
-import api._
+
+import api._, all._
 
 /** Having an Empty[A] instance in scope allows for using methods
  *  like zfold, zreduce, zhead, whereupon the implicit empty value

--- a/std/src/main/scala/EqOrder.scala
+++ b/std/src/main/scala/EqOrder.scala
@@ -1,0 +1,66 @@
+package psp
+package std
+
+import api._, all._
+
+trait PrimitiveInstances {
+  implicit def boolOrder: Order[Bool]   = orderBy[Bool](x => if (x) 1 else 0)
+  implicit def byteOrder: Order[Byte]   = Order.fromInt(_ - _)
+  implicit def charOrder: Order[Char]   = Order.fromInt[Char](_ - _)
+  implicit def shortOrder: Order[Short] = Order.fromInt[Short](_ - _)
+  implicit def intOrder: Order[Int]     = Order.fromInt[Int](_ - _)
+  implicit def longOrder: Order[Long]   = Order.fromLong[Long](_ - _)
+  implicit def unitOrder: Order[Unit]   = Order.fromInt[Unit]((x, y) => 0)
+}
+
+trait EqOrderInstances0 {
+  // If this is written in the obvious way, i.e.
+  //
+  //   implicit def comparableOrder[A <: Comparable[A]] : Order[A]
+  //
+  // Then it isn't found for infix operations on Comparables. We also can't call
+  // Order.natural[A]() because it has that bound, despite the implicit witness.
+  implicit def comparableOrder[A](implicit ev: A <:< Comparable[A]): Order[A] = Order.fromInt[A](_ compareTo _)
+}
+
+trait EqOrderInstances1 extends EqOrderInstances0 {
+  private def corresponds[A](xs: Foreach[A], ys: Foreach[A])(implicit z: Eq[A]): Boolean = {
+    val it1 = BiIterator(xs)
+    val it2 = BiIterator(ys)
+    while (it1.hasNext && it2.hasNext) {
+      if (!z.eqv(it1.next, it2.next))
+        return false
+    }
+    !(it1.hasNext || it2.hasNext)
+  }
+
+  implicit def unbuildsEq[R, A](implicit b: UnbuildsAs[A, R], e: Eq[A]): Eq[R] =
+    Eq[R]((xs, ys) => corresponds(b unbuild xs, b unbuild ys))
+}
+
+trait EqOrderInstances extends EqOrderInstances1 {
+  // Some unfortunate rocket dentistry necessary here.
+  // This doesn't work because scala comes up with "Any" due to the fbound.
+  // implicit def enumOrder[A <: jEnum[A]]: Order[A] = Order.fromInt[A](_.ordinal - _.ordinal)
+  //
+  // This one doesn't work if it's A <:< jEnum[A], but jEnum[_] is just enough to get what we need.
+  implicit def enumOrder[A](implicit ev: A <:< jEnum[_]): Order[A]          = orderBy[A](_.ordinal)
+
+  implicit def indexOrder: Order[Index]                                     = orderBy[Index](_.get)
+  implicit def preciseOrder: Order[Precise]                                 = orderBy[Precise](_.get)
+  implicit def stringOrder: Order[String]                                   = Order.fromLong[String](_ compareTo _)
+  implicit def tuple2Order[A: Order, B: Order] : Order[(A, B)]              = orderBy[(A, B)](fst) | snd
+  implicit def tuple3Order[A: Order, B: Order, C: Order] : Order[(A, B, C)] = orderBy[(A, B, C)](_._1) | (_._2) | (_._3)
+
+  implicit def docEq: Hash[Doc]                = inheritEq
+  implicit def classWrapperEq: Hash[JavaClass] = inheritEq
+  implicit def classEq: Hash[Class[_]]         = inheritEq
+  implicit def pathEq: Eq[jPath]               = shownEq[jPath](inheritShow)
+  implicit def sizeEq: Hash[Size]              = inheritEq
+
+  implicit def tryEq[A](implicit z1: Eq[A], z2: Eq[Throwable]): Eq[Try[A]] = Eq {
+    case (Success(x), Success(y)) => x === y
+    case (Failure(x), Failure(y)) => x === y
+    case _                        => false
+  }
+}

--- a/std/src/main/scala/ExSet.scala
+++ b/std/src/main/scala/ExSet.scala
@@ -1,7 +1,8 @@
 package psp
 package std
 
-import api._, Unsafe.inheritedShow
+
+import api._, all._, Unsafe.inheritedShow
 
 object ExSet {
   def apply[A: Eq](xs: Each[A]): ExSet[A]  = new Impl[A](xs, ?)

--- a/std/src/main/scala/HashEqOrder.scala
+++ b/std/src/main/scala/HashEqOrder.scala
@@ -1,7 +1,8 @@
 package psp
 package std
 
-import api._
+
+import api._, all._
 import scala.math.Ordering
 import spire.{ algebra => sa }
 

--- a/std/src/main/scala/Index.scala
+++ b/std/src/main/scala/Index.scala
@@ -1,7 +1,8 @@
 package psp
 package std
 
-import api._
+
+import api._, all._
 
 /** A valid index is always non-negative. All negative indices are
  *  mapped to NoIndex, which has an underlying value of -1.

--- a/std/src/main/scala/Indexed.scala
+++ b/std/src/main/scala/Indexed.scala
@@ -1,7 +1,8 @@
 package psp
 package std
 
-import api._, StdEq._
+
+import api._, all._, StdEq._
 import java.util.concurrent.LinkedBlockingQueue
 
 object indices {

--- a/std/src/main/scala/LowLevel.scala
+++ b/std/src/main/scala/LowLevel.scala
@@ -2,7 +2,8 @@ package psp
 package std
 package lowlevel
 
-import api._, StdEq._
+
+import api._, all._, StdEq._
 import scala.Tuple2
 import java.nio.ByteBuffer
 import java.io.{ ByteArrayOutputStream, BufferedInputStream }

--- a/std/src/main/scala/Map.scala
+++ b/std/src/main/scala/Map.scala
@@ -1,7 +1,7 @@
 package psp
 package std
 
-import api._
+import api._, all._
 
 object Fun {
   private val Undefined: Opaque[Any, Nothing] = Opaque[Any, Nothing](illegalArgumentException)
@@ -18,8 +18,8 @@ object ExMap {
   def empty[K, V] : ExMap[K, V]                                   = apply(Fun.finite())
   def apply[K, V](f: FiniteDom[K, V]): ExMap[K, V]                = new Impl(f)
   def apply[K, V](keys: ExSet[K], lookup: Fun[K, V]): ExMap[K, V] = apply(FiniteDom(keys, lookup))
-  def fromJava[K, V](xs: jMap[K, V]): ExMap[K, V]                 = fromScala(xs.m.toScalaMap)
-  def fromScala[K, V](xs: scMap[K, V]): ExMap[K, V]               = apply(xs.keys.byEquals.toSet, Opaque(xs))
+  def fromJava[K, V](xs: jMap[K, V]): ExMap[K, V]                 = apply[K, V](ExSet fromJava xs.keySet, Opaque[K, V](xs get _)) //   fromScala[K, V](xs.m.toScalaMap)
+  def fromScala[K, V](xs: scMap[K, V]): ExMap[K, V]               = apply[K, V](xs.keys.byEquals.toSet, Opaque(xs))
 
   def impl[K, V](xs: ExMap[K, V]): Impl[K, V] = xs match {
     case xs: Impl[K, V] => xs

--- a/std/src/main/scala/Plist.scala
+++ b/std/src/main/scala/Plist.scala
@@ -1,7 +1,8 @@
 package psp
 package std
 
-import api._
+
+import api._, all._
 
 sealed abstract class Plist[A] extends Each[A] {
   def head: A

--- a/std/src/main/scala/Pstring.scala
+++ b/std/src/main/scala/Pstring.scala
@@ -1,7 +1,8 @@
 package psp
 package std
 
-import api._, StdShow._, StdEq._
+
+import api._, all._, StdShow._, StdEq._
 import java.{ lang => jl }
 import java.util.regex.{ Pattern, Matcher }
 import jl.Integer.parseInt, jl.Long.parseLong, jl.Double.parseDouble, jl.Float.parseFloat

--- a/std/src/main/scala/Show.scala
+++ b/std/src/main/scala/Show.scala
@@ -1,7 +1,7 @@
 package psp
 package std
 
-import api._, StdShow._, StdEq._
+import api._, all._, StdShow._, StdEq._
 
 class FullRenderer extends Renderer {
   def minElements: Precise = 3

--- a/std/src/main/scala/StdPackage.scala
+++ b/std/src/main/scala/StdPackage.scala
@@ -6,15 +6,7 @@ import java.nio.file.{ attribute => jnfa }
 import psp.api._
 import psp.ext.ExternalLibs
 
-abstract class StdPackageObject extends scala.AnyRef
-      with StdEmpty
-      with StdJava
-      with PrimitiveInstances
-      with AlgebraInstances
-      with StdImplicits
-      with PspApi {
-
-
+trait StdAllParent extends PspApi {
   // Type aliases I don't like enough to have in the API.
   type Bag[A]               = ExMap[A, Precise]
   type Bool                 = Boolean
@@ -25,6 +17,40 @@ abstract class StdPackageObject extends scala.AnyRef
   type Renderer             = Show[Doc]
   type UnbuildsAs[+A, R]    = Unbuilds[R] { type Elem <: A }
   type View2D[+A]           = View[View[A]]
+
+  // Helpers for inference when calling 'on' on contravariant type classes.
+  def eqBy[A]    = new EqBy[A]
+  def orderBy[A] = new OrderBy[A]
+  def showBy[A]  = new ShowBy[A]
+  def hashBy[A]  = new HashBy[A]
+
+  def render[A](x: A)(implicit z: Show[A]): String = z show x
+  def lexicalOrder: Order[String]                  = Order.fromInt(_ compareTo _)
+  def inheritShow[A] : Show[A]                     = Show.Inherited
+  def inheritEq[A] : Hash[A]                       = Eq.Inherited
+  def referenceEq[A <: AnyRef] : Hash[A]           = Eq.Reference
+  def stringEq[A] : Hash[A]                        = Eq.ToString
+  def shownEq[A: Show] : Hash[A]                   = hashBy[A](x => render(x))(Eq.ToString)
+
+  def fst[A, B](x: A -> B): A          = x._1
+  def snd[A, B](x: A -> B): B          = x._2
+  def tuple[A, B](x: A -> B): ((A, B)) = scala.Tuple2(x._1, x._2)
+  def swap[A, B](x: A -> B): B -> A    = scala.Tuple2(x._2, x._1)
+  def swap[A, B](x: A, y: B): B -> A   = scala.Tuple2(y, x)
+
+  def inView[A](mf: Suspended[A]): View[A] = new LinearView(Each(mf))
+}
+private[std] object StdAllParent extends StdAllParent
+
+abstract class StdAll extends scala.AnyRef
+      with StdAllParent
+      with StdEmpty
+      with StdJava
+      with PrimitiveInstances
+      with AlgebraInstances
+      with StdImplicits
+      with PspCreators
+      with PspApi {
 
   // Ugh. XXX
   implicit def promoteSize(x: Long): Precise                     = Size(x)
@@ -37,25 +63,10 @@ abstract class StdPackageObject extends scala.AnyRef
   implicit def opsDirect[A](xs: Direct[A]): ops.DirectOps[A]     = new ops.DirectOps(xs)
   implicit def opsForeach[A](xs: Foreach[A]): ops.ForeachOps[A]  = new ops.ForeachOps(xs)
 
-  def lexicalOrder: Order[String] = Order.fromInt(_ compareTo _)
-
-  def inheritShow[A] : Show[A]           = Show.Inherited
-  def inheritEq[A] : Hash[A]             = Eq.Inherited
-  def referenceEq[A <: AnyRef] : Hash[A] = Eq.Reference
-  def stringEq[A] : Hash[A]              = Eq.ToString
-  def shownEq[A: Show] : Hash[A]         = hashBy[A](x => render(x))(Eq.ToString)
-
-  // Helpers for inference when calling 'on' on contravariant type classes.
-  def eqBy[A]    = new EqBy[A]
-  def orderBy[A] = new OrderBy[A]
-  def showBy[A]  = new ShowBy[A]
-  def hashBy[A]  = new HashBy[A]
-
   private def stdout                  = scala.Console.out
   private def putOut(msg: Any): Unit  = sideEffect(stdout print msg, stdout.flush())
   private def echoOut(msg: Any): Unit = stdout println msg
 
-  def render[A](x: A)(implicit z: Show[A]): String = z show x
   def print[A: Show](x: A): Unit   = putOut(render(x))
   def println[A: Show](x: A): Unit = echoOut(render(x))
   def anyprintln(x: Any): Unit     = echoOut(x.any_s)
@@ -96,23 +107,16 @@ abstract class StdPackageObject extends scala.AnyRef
   def randomPosInt(max: Int): Int                    = scala.util.Random.nextInt(max + 1)
   def leftFormatString[A](n: Int): FormatFun         = new FormatFun(cond(n == 0, "%s", "%%-%ds" format n))
 
-  def fst[A, B](x: A -> B): A          = x._1
-  def snd[A, B](x: A -> B): B          = x._2
-  def tuple[A, B](x: A -> B): ((A, B)) = x._1 -> x._2
-  def swap[A, B](x: A -> B): B -> A    = x._2 -> x._1
-  def swap[A, B](x: A, y: B): B -> A   = y -> x
-
   def make[R](xs: R): RemakeHelper[R]  = new RemakeHelper[R](xs)
   def make0[R] : MakeHelper[R]         = new MakeHelper[R]
   def make1[CC[_]] : MakeHelper1[CC]   = new MakeHelper1[CC]
   def make2[CC[_,_]] : MakeHelper2[CC] = new MakeHelper2[CC]
 
   def cond[A](p: Bool, thenp: => A, elsep: => A): A = if (p) thenp else elsep
-  def inView[A](mf: Suspended[A]): View[A]          = new LinearView(Each(mf))
   def list[A](xs: A*): Plist[A]                     = xs.toPlist
   def rel[K: Eq, V](xs: (K->V)*): ExMap[K, V]       = xs.m.toExMap
   def set[A: Eq](xs: A*): ExSet[A]                  = xs.toExSet
-  def vec[@fspec A](xs: A*): Vec[A]                 = xs.toVec
+  def vec[A](xs: A*): Vec[A]                        = xs.toVec
   def view[A](xs: A*): View[A]                      = xs.toVec.m
   def zip[A, B](xs: (A->B)*): ZipView[A, B]         = Zip zip1 xs.m
 }

--- a/std/src/main/scala/Vec.scala
+++ b/std/src/main/scala/Vec.scala
@@ -1,7 +1,8 @@
 package psp
 package std
 
-import api._, StdShow._, StdEq._
+
+import api._, all._, StdShow._, StdEq._
 import Vec._
 import java.lang.{ Math => math }
 

--- a/std/src/main/scala/WrapJava.scala
+++ b/std/src/main/scala/WrapJava.scala
@@ -1,7 +1,7 @@
 package psp
 package std
 
-import api._, StdEq._
+import api._, all._, StdEq._
 import java.nio.{ file => jnf }
 import java.nio.file.{ attribute => jnfa }
 import java.net.URLClassLoader

--- a/std/src/main/scala/Zip.scala
+++ b/std/src/main/scala/Zip.scala
@@ -1,7 +1,8 @@
 package psp
 package std
 
-import api._, StdEq._
+
+import api._, all._, StdEq._
 
 final case class Split[A](left: View[A], right: View[A]) extends api.SplitView[A] {
   def onRight[B](f: View[A] => B): B            = f(right)

--- a/std/src/main/scala/ops/Array.scala
+++ b/std/src/main/scala/ops/Array.scala
@@ -2,7 +2,8 @@ package psp
 package std
 package ops
 
-import api._
+
+import api._, all._
 import spire.math.Sorting
 
 final class ArrayClassTagOps[A: CTag](val xs: Array[A]) {

--- a/std/src/main/scala/ops/Java.scala
+++ b/std/src/main/scala/ops/Java.scala
@@ -1,10 +1,10 @@
 package psp
 package std
 
-import api._
+import api._, all._
 import java.util.stream.Stream.{ builder => jStreamBuilder }
 
-object Java extends JavaCollections with JavaBuilders
+object Java extends JavaCollections
 
 trait StdJava0 {
   implicit def viewJavaStream[A, CC[X] <: jStream[X]](xs: CC[A]): AtomicView[A, CC[A]]               = new StreamView(xs)

--- a/std/src/main/scala/ops/Primitive.scala
+++ b/std/src/main/scala/ops/Primitive.scala
@@ -3,7 +3,8 @@ package std
 package ops
 
 import java.{ lang => jl }
-import api._
+
+import api._, all._
 
 final class AnyOps[A](val x: A) extends AnyVal {
   def any_s: String                         = s"$x"

--- a/std/src/main/scala/ops/Psp.scala
+++ b/std/src/main/scala/ops/Psp.scala
@@ -2,7 +2,8 @@ package psp
 package std
 package ops
 
-import api._, StdEq._, StdShow._
+
+import api._, all._, StdEq._, StdShow._
 import java.io.BufferedInputStream
 
 final class DirectOps[A](val xs: Direct[A]) extends AnyVal {
@@ -26,10 +27,6 @@ final class ForeachOps[A](val xs: Foreach[A]) {
   private[this] def to[CC[X]](implicit z: Builds[A, CC[A]]): CC[A] = z build Each(xs foreach _)
   def trav: scTraversable[A] = to[scTraversable] // flatMap, usually
   def seq: scSeq[A]          = to[scSeq]         // varargs or unapplySeq, usually
-}
-
-final class DocSeqOps(xs: Direct[Doc]) {
-  def joinLines: String = xs mapNow (_.render) mk_s EOL
 }
 final class DocOps(val lhs: Doc) extends AnyVal {
   def doc: Doc                             = lhs

--- a/std/src/main/scala/ops/ScalaLibrary.scala
+++ b/std/src/main/scala/ops/ScalaLibrary.scala
@@ -2,7 +2,8 @@ package psp
 package std
 package ops
 
-import api._
+
+import api._, all._
 
 /** Extension methods for scala library classes.
  *  We'd like to get away from all such classes,

--- a/std/src/main/scala/ops/TypeClass.scala
+++ b/std/src/main/scala/ops/TypeClass.scala
@@ -2,7 +2,8 @@ package psp
 package std
 package ops
 
-import api._
+
+import api._, all._
 
 /** There are two kinds of extension methods associated with
  *  type classes.

--- a/std/src/main/scala/ops/View.scala
+++ b/std/src/main/scala/ops/View.scala
@@ -2,7 +2,7 @@ package psp
 package std
 package ops
 
-import api._, StdShow._, StdEq._
+import api._, all._, StdShow._, StdEq._
 
 trait ViewOps[+A] extends Any {
   def xs: View[A]

--- a/std/src/main/scala/package.scala
+++ b/std/src/main/scala/package.scala
@@ -1,8 +1,0 @@
-package psp
-
-package object std extends psp.std.StdPackageObject {
-  final val NoIndex       = Index.invalid
-  final val NoFile: jFile = jFile("")
-  final val NoPath: jPath = jPath("")
-  final val NoUri: jUri   = jUri("")
-}

--- a/std/src/main/scala/vecutil.scala
+++ b/std/src/main/scala/vecutil.scala
@@ -1,6 +1,7 @@
 package psp
 package std
 
+import all._
 import Vec._
 import StdShow._
 


### PR DESCRIPTION
Package objects are misery. This is about the 100th bug
I've reported against package objects. Hopefully the last.

  https://issues.scala-lang.org/browse/SI-9580

That bug destroys any hope of separating interface and
implementation when package objects are involved, so let's
just forget the whole thing.

As always, this change reveals a bunch of inexplicable
scala bugs, especially with type inference.

[error] could not find implicit value for parameter z: UnbuildsAs[this.Elem, jMap[String,Int]]
[error]         jmap.m build,
[error]         ^

The "this.Elem" is a typical scala substitution bug.