### PR TITLE
A fix, an improvement and some scalac opts

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -12,8 +12,15 @@ object Build extends sbt.Build {
   def ammoniteDep         = "com.lihaoyi" % "ammonite-repl" % ammoniteVersion cross CrossVersion.full
   def consoleDependencies = List(jsr305, ammoniteDep)
   def bonusArgs           = wordSeq(sys.env.getOrElse("SCALAC_ARGS", ""))
+  def encodingArgs        = wordSeq("-encoding utf8")
+  def pspArgs             = wordSeq("-language:_ -Yno-predef -Yno-imports")
+  def baseArgs            = wordSeq("-deprecation -unchecked -Xfuture -Yno-adapted-args")
+  def noisyArgs           = wordSeq("-Xlint -Ywarn-dead-code -Ywarn-numeric-widen -Ywarn-value-discard")
+  def warnArgs            = wordSeq("-Ywarn-unused -Ywarn-unused-import")
+  def macroDebugArgs      = wordSeq("-Ymacro-debug-verbose")
   def optimizeArgs        = wordSeq("-optimise -Yinline-warnings")
-  def stdArgs             = wordSeq("-language:_ -Yno-predef -Yno-adapted-args -Yno-imports -unchecked") // -Ymacro-debug-verbose
+  def stdArgs             = encodingArgs ++ pspArgs ++ baseArgs ++ warnArgs
+
   def testDependencies    = Def setting Seq(Deps.scalaReflect.value, scalacheck.copy(configurations = None))
 
   lazy val api = project setup "psp's non-standard api" also spire

--- a/std/src/main/scala/Show.scala
+++ b/std/src/main/scala/Show.scala
@@ -78,7 +78,7 @@ trait ShowInstances extends ShowEach {
   implicit def showIndex: Show[Index]                                   = showBy(_.get)
   implicit def showOption[A: Show] : Show[Option[A]]                    = Show(_.fold("-")(_.render))
   implicit def showPair[A: Show, B: Show] : Show[A -> B]                = Show(x => x._1 ~ " -> " ~ x._2 render)
-  implicit def showStackTraceElement: Show[java.lang.StackTraceElement] = Show(x => "\tat$x\n")
+  implicit def showStackTraceElement: Show[java.lang.StackTraceElement] = Show(x => s"\tat$x\n")
 
   implicit def showSize: Show[Size] = Show[Size] {
     case Finite(size)          => pp"$size"

--- a/std/src/main/scala/ops/Array.scala
+++ b/std/src/main/scala/ops/Array.scala
@@ -33,7 +33,7 @@ final class InPlace[A](val xs: Array[A]) extends AnyVal {
     case _                => false
   }
   private def midpoint: Int  = xs.length / 2
-  private def swap(i1: Int, i2: Int) {
+  private def swap(i1: Int, i2: Int): Unit = {
     val tmp = xs(i1)
     xs(i1) = xs(i2)
     xs(i2) = tmp


### PR DESCRIPTION
* Fix showStackTraceElement
* Remove a procedure syntax
* Add some scalac options (below)

Added the following scalac options:

* `-encoding utf8`
* `-deprecation`
* `-Xfuture`
* `-Ywarn-unused`
* `-Ywarn-unused-import`

Also created `noisyArgs`:

* `-Xlint`
* `-Ywarn-dead-code`
* `-Ywarn-numeric-widen`
* `-Ywarn-value-discard`

I think these are good options to have but they currently add a lot of noise.