### PR TITLE
Remove unnecessary definitions from BUILD.tools

### DIFF
--- a/BUILD.tools
+++ b/BUILD.tools
@@ -1,9 +1,4 @@
 #
-SCALA_REV = '2.11.7'
-
-jar_library(name = 'scalac_2_11',   jars =    [ jar(org    =           'org.scala-lang', name = 'scala-compiler', rev       = SCALA_REV) ])
-jar_library(name = 'scala-library', jars =    [ jar(org    =           'org.scala-lang', name = 'scala-library', rev        = SCALA_REV), ])
-jar_library(name = 'jline',         jars =    [ jar(org    =                    'jline', name = 'jline', rev                =   '2.13') ])
 jar_library(name = 'spire', jars         = [ scala_jar(org =           'org.spire-math', name = 'spire', rev                = '0.11.0'), ])
 jar_library(name = 'scalacheck', jars    = [ scala_jar(org =           'org.scalacheck', name = 'scalacheck', rev           = '1.12.5'), ])
 # jar_library(name = 'scalatest', jars     = [ scala_jar(org =           'org.scalatest',  name = 'scalatest', rev            = '2.2.4'), ])

--- a/pants.ini
+++ b/pants.ini
@@ -3,21 +3,9 @@
 pants_version: 0.0.70
 
 # print_exception_stacktrace: True
-local_artifact_cache = %(pants_bootstrapdir)s/artifact_cache
 
 # [jvm]
 # options: [ "-Xmx1g" ]
-
-[cache.bootstrap]
-# The just-in-time tool shading performed by jvm tool bootstrapping is very expensive,
-# so we turn on artifact caching for it that can survive clean-all.
-read_from = ["%(local_artifact_cache)s"]
-write_to  = ["%(local_artifact_cache)s"]
-
-[goals]
-bootstrap_buildfiles: [
-    '%(buildroot)s/BUILD',
-  ]
 
 [scala-platform]
 version: 2.11


### PR DESCRIPTION
As of `0.0.69`, pants includes default classpaths for scala 2.10 and 2.11. Setting:
```
[scala-platform]
version: 2.11
```
... in `pants.ini` is sufficient to get 2.11.7 by default.

Additionally, as of `0.0.70`, bootstrap is fully cache safe, so the default cache settings are now fine.