### PR TITLE
Migrate away from sbt.Build to build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,10 @@
+val root        = fbt.Build.root
+val api         = fbt.Build.api
+val std         = fbt.Build.std
+val consoleOnly = fbt.Build.consoleOnly
+val testing     = fbt.Build.testing
+val benchmark   = fbt.Build.benchmark
+
 // To sync with Maven central, you need to supply the following information:
 pomExtra in Global := (
   <url>https://github.com/paulp/psp-std</url>

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -3,7 +3,7 @@ package fbt
 import sbt._, Keys._
 import pl.project13.scala.sbt.JmhPlugin
 
-object Build extends sbt.Build with FbtBuild {
+object Build extends FbtBuild {
   lazy val api = project setup "psp's non-standard api" also spire
   lazy val std = project setup "psp's non-standard standard library" dependsOn api
 

--- a/project/Sbt.scala
+++ b/project/Sbt.scala
@@ -3,8 +3,6 @@ package fbt
 import sbt._, Keys._
 
 trait FbtBuild {
-  self: sbt.Build =>
-
   def subprojects: List[sbt.Project]
   protected def commonSettings(p: Project): Seq[Setting[_]]
 


### PR DESCRIPTION
For context sbt.Build is going away in sbt 1.0 (becoming private & renamed).

This is _a_ way to migrate away from it, minimal, but achieves the intend goal - but I'm not sure it's the way you would prefer it.

So, submitted for early feedback, happy to iterate, fine if you'd rather leave it or take care of it yourself.