### PR TITLE
Throw scala.StringContext out

### DIFF
--- a/macros/src/main/scala/Typechecked.scala
+++ b/macros/src/main/scala/Typechecked.scala
@@ -2,6 +2,7 @@ package psp
 package std
 package macros
 
+import scala.StringContext
 import scala.reflect.macros.blackbox.Context
 import all._
 

--- a/macros/src/test/scala/generate.scala
+++ b/macros/src/test/scala/generate.scala
@@ -1,7 +1,7 @@
 package psp
 package tests
 
-import psp.std._, all._
+import psp.std._, all._, StdShow._
 
 /** TODO - actually generate the code via an sbt generator.
  */
@@ -18,17 +18,17 @@ object Generator {
     "pspStraight"      -> ""
   )
   def vals = for ((name, stub) <- envs) yield {
-    val lines = for (l <- lhses; op <- ops; r <- rhses) yield s"$l$stub $op $r"
-    s"  final val $name = " + tq + "\n    " + (lines mkString "\n    ") + "\n  " + tq
+    val lines = for (l <- lhses; op <- ops; r <- rhses) yield pp"$l$stub $op $r"
+    pp"  final val $name = " + tq + "\n    " + (lines mkString "\n    ") + "\n  " + tq
   }
-  def template = s"""
+  def template = sm"""
     |package psp
     |package tests
     |package generated
     |
     |object Expressions {
     |  ${ vals mkString "\n" }
-    |}""".stripMargin
+    |}"""
 }
 
 object Expressions {

--- a/repl/ammonite.scala
+++ b/repl/ammonite.scala
@@ -23,7 +23,7 @@ class REPL(storage: Ref[Storage], initCode: String, scalacArgs: Vec[String]) ext
   override val frontEnd = Ref[FrontEnd](FrontEnd.JLineUnix)
   override val prompt   = Ref("psp> ")
 
-  private def banner               = s"\npsp-std repl (ammonite $ammoniteVersion, scala $scalaVersion, jvm $javaVersion)"
+  private def banner               = pp"\npsp-std repl (ammonite $ammoniteVersion, scala $scalaVersion, jvm $javaVersion)"
   override def printBanner(): Unit = printStream println banner
 
   import interp.replApi._

--- a/std/src/main/scala/std/ADTs.scala
+++ b/std/src/main/scala/std/ADTs.scala
@@ -1,7 +1,8 @@
 package psp
 package std
 
-import exp._, Size._, all.PspLongOps
+import exp._, Size._, StdShow._, all.{ PspLongOps, showsToDoc }
+
 
 /** The Size hierarchy is:
   *                     Size
@@ -61,7 +62,7 @@ final class Precise private[std](val getLong: Long) extends Atomic {
   def indices: VdexRange      = 0L indexUntil getLong
   def lastIndex: Index        = exclusive.prev // effectively maps both undefined and zero to no index.
 
-  override def toString = s"$getLong"
+  override def toString = pp"$getLong"
 }
 final case class Bounded private[std](lo: Precise, hi: Atomic) extends Size
 

--- a/std/src/main/scala/std/All.scala
+++ b/std/src/main/scala/std/All.scala
@@ -19,7 +19,6 @@ object Unsafe {
 object exp extends AllExplicit
 
 object all extends AllExplicit with AllImplicit {
-  implicit class PspStringContextOps(val stringContext: StringContext) extends Interpolators
   implicit class PspAnyOps[A](private val x: A) extends AnyVal {
     /** Call this on any value. Produce a view.
      *  If a value of the same type as the original can be
@@ -28,7 +27,7 @@ object all extends AllExplicit with AllImplicit {
      */
     def o[B](f: A => View[B])(implicit z: Makes[B, A]): A = z make f(x)
 
-    def any_s: String                     = s"$x"
+    def any_s: String                     = any"$x"
     def id_## : Int                       = java.lang.System.identityHashCode(x)
     def id_==(y: Any): Boolean            = cast[AnyRef](x) eq cast[AnyRef](y)
     def matchIf[B: Empty](pf: A ?=> B): B = if (pf isDefinedAt x) pf(x) else emptyValue

--- a/std/src/main/scala/std/Api.scala
+++ b/std/src/main/scala/std/Api.scala
@@ -5,7 +5,7 @@ import scala.{ Tuple3, collection => sc }
 import java.{ lang => jl }
 import java.nio.{ file => jnf }
 import java.util.AbstractMap.SimpleImmutableEntry
-import exp._
+import StdShow._, exp._, all.showsToDoc
 
 trait ApiTypes extends ExternalTypes {
   // Aliases for internal and external types.
@@ -50,12 +50,12 @@ abstract class ApiValues extends ApiTypes {
   final val EOL     = jl.System getProperty "line.separator"
 
   def ??? : Nothing                                 = throw new scala.NotImplementedError
-  def abort(msg: Any): Nothing                      = throw new RuntimeException(s"$msg")
+  def abort(msg: Any): Nothing                      = throw new RuntimeException(any"$msg")
   def assert(assertion: => Bool, msg: => Any): Unit = if (!assertion) assertionError(msg)
-  def assertionError(msg: Any): Nothing             = throw new AssertionError(s"$msg")
-  def illegalArgumentException(msg: Any): Nothing   = throw new IllegalArgumentException(s"$msg")
-  def indexOutOfBoundsException(msg: Any): Nothing  = throw new IndexOutOfBoundsException(s"$msg")
-  def noSuchElementException(msg: Any): Nothing     = throw new NoSuchElementException(s"$msg")
+  def assertionError(msg: Any): Nothing             = throw new AssertionError(any"$msg")
+  def illegalArgumentException(msg: Any): Nothing   = throw new IllegalArgumentException(any"$msg")
+  def indexOutOfBoundsException(msg: Any): Nothing  = throw new IndexOutOfBoundsException(any"$msg")
+  def noSuchElementException(msg: Any): Nothing     = throw new NoSuchElementException(any"$msg")
 
   def ?[A](implicit value: A): A                              = value
   def _0[A](implicit z: ZeroOne[A]): A                        = z.zero
@@ -100,7 +100,7 @@ abstract class ApiValues extends ApiTypes {
   def safeLongToInt(value: Long): Int = value match {
     case MaxLong => MaxInt
     case MinLong => MinInt
-    case _       => assert(MinInt <= value && value <= MaxInt, s"$value out of range"); value.toInt
+    case _       => assert(MinInt <= value && value <= MaxInt, pp"$value out of range"); value.toInt
   }
 
   def stringFormat(s: String, args: Any*): String = {
@@ -110,7 +110,4 @@ abstract class ApiValues extends ApiTypes {
     }
     java.lang.String.format(s, args map unwrapArg: _*)
   }
-
-  // You can't use string interpolation without a stringContext term in scope.
-  lazy val StringContext = scala.StringContext
 }

--- a/std/src/main/scala/std/AtomicView.scala
+++ b/std/src/main/scala/std/AtomicView.scala
@@ -9,7 +9,7 @@ trait View[+A] extends Any with Foreach[A] {
 }
 
 final case class IdView[A, R](underlying: Foreach[A]) extends RView[A, R] {
-  override def toString = s"Id(${ underlying.size.pp })"
+  override def toString = pp"Id(${ underlying.size })"
 }
 
 trait RView[A, R] extends View[A] with ViewClasses[A, R] {

--- a/std/src/main/scala/std/ExternalTypes.scala
+++ b/std/src/main/scala/std/ExternalTypes.scala
@@ -17,7 +17,7 @@ import java.nio.{ file => jnf }
   *   - Seq is hardcoded into varargs
   *   - Arrays are everywhere special
   *   - Lists are specially optimized by the compiler
-  *   - stringContext is required for string interpolation
+  *   - A StringContext term is required for string interpolation
   *   - ClassTags are synthesized by the compiler
   *   - BigDecimal/BigInt are treated specially for equality
   *   - Dynamic has special semantics
@@ -56,7 +56,6 @@ trait ExternalTypes {
   type Failure[+A]    = scala.util.Failure[A]
   type Option[+A]     = scala.Option[A]
   type Some[+A]       = scala.Some[A]
-  type StringContext  = scala.StringContext
   type Success[+A]    = scala.util.Success[A]
   type Try[+A]        = scala.util.Try[A]
   type Tuple2[+A, +B] = scala.Tuple2[A, B]

--- a/std/src/main/scala/std/Pstring.scala
+++ b/std/src/main/scala/std/Pstring.scala
@@ -78,7 +78,7 @@ final class Regex(val pattern: Pattern) extends ShowSelf {
   def prepend(s: String): Regex              = mapRegex(s + _)
   def starts: Regex                          = cond(to_s startsWith "^", this, prepend("^"))
   def surround(s: String, e: String): Regex  = mapRegex(_.surround(s, e))
-  def to_s: String                           = s"$pattern"
+  def to_s: String                           = pp"$pattern"
 
   def <>(that: Regex): Regex = mapRegex(_ + that.pattern)
   def |(that: Regex): Regex  = mapRegex(_ + "|" + that.pattern)
@@ -87,7 +87,7 @@ final class Regex(val pattern: Pattern) extends ShowSelf {
 object Regex extends (String => Regex) {
   val WS = apply("\\s*")
 
-  def apply(ch: Char): Regex              = apply(s"[$ch]")
+  def apply(ch: Char): Regex              = apply(pp"[$ch]")
   def quote(s: String): Regex             = apply(Pattern quote s)
   def apply(s: String): Regex             = new Regex(Pattern compile s)
   def apply(s: String, flags: Int): Regex = new Regex(Pattern.compile(s, flags))

--- a/std/src/test/scala/main/TestPackage.scala
+++ b/std/src/test/scala/main/TestPackage.scala
@@ -51,7 +51,7 @@ trait Explicit {
   implicit def genToArb[A](g: Gen[A]): Arb[A] = Arb(g)
   implicit def arbToGen[A](g: Arb[A]): Gen[A] = g.arbitrary
 
-  def assert(p: => Boolean, msg: => Any)(implicit z: Assertions): Unit = Assertions.using(z)(p, s"assertion failed: $msg")
+  def assert(p: => Boolean, msg: => Any)(implicit z: Assertions): Unit = Assertions.using(z)(p, any"assertion failed: $msg")
   def associative[A: Arb : Eq](f: BinOp[A]): Prop                      = forAll((a: A, b: A, c: A) => sameBehavior(f(f(a, b), c), f(a, f(b, c))))
   def commutative[A: Arb : Eq](f: BinOp[A]): Prop                      = forAll((a: A, b: A) => sameBehavior(f(a, b), f(b, a)))
   def expectType(expected: jClass, found: jClass): NamedProp           = fp"$expected%15s  >:>  $found%s" -> Prop(expected isAssignableFrom found)

--- a/std/src/test/scala/tests/MiscSpec.scala
+++ b/std/src/test/scala/tests/MiscSpec.scala
@@ -29,8 +29,8 @@ class ADTSpec extends ScalacheckBundle {
 
   var seen = ""
   val m1 = f1.traced(
-    x => seen += s"f($x): ",
-    x => seen += s"$x "
+    x => seen += pp"f($x): ",
+    x => seen += pp"$x "
   )
 
   lazy val m1trace = {

--- a/std/src/test/scala/tests/MiscSpec.scala
+++ b/std/src/test/scala/tests/MiscSpec.scala
@@ -7,6 +7,21 @@ import Prop.forAll
 class MiscTests {
   @Test(expected = Predef.classOf[AssertionError])
   def junitFail(): Unit = junitAssert(false)
+
+  @Test(expected = Predef.classOf[scala.NotImplementedError])
+  def notImplementedError(): Unit = ???
+
+  @Test
+  def assertTrue(): Unit = assert(true, "boom")
+
+  @Test(expected = Predef.classOf[IllegalArgumentException])
+  def iae(): Unit = illegalArgumentException("boom")
+
+  @Test(expected = Predef.classOf[IndexOutOfBoundsException])
+  def ioobe(): Unit = indexOutOfBoundsException("boom")
+
+  @Test(expected = Predef.classOf[NoSuchElementException])
+  def nsee(): Unit = noSuchElementException("boom")
 }
 
 class ArraySpec extends ScalacheckBundle {

--- a/std/src/test/scala/tests/TypeClassSpec.scala
+++ b/std/src/test/scala/tests/TypeClassSpec.scala
@@ -107,7 +107,7 @@ class ViewBasic extends ScalacheckBundle {
       expectValue(5)(view(5).zhead)
       // Just to observe the scalacheck arguments being generated
       // , "dump" -> sameOutcomes[RTriple, Unit](
-      //   { case xs -> (idx -> size) => { println(s"$xs -> ($idx -> $size)") ; () } },
+      //   { case xs -> (idx -> size) => { println(pp"$xs -> ($idx -> $size)") ; () } },
       //   { case xs -> (idx -> size) => () }
       // )
     )


### PR DESCRIPTION
For string interpolation Scala requires there to be a `StringContext` term in scope, but that doesn't have to be `scala.StringContext`:

```scala
// Documenting that it is intentional that the ident is not rooted for purposes of virtualization
//val t1 = atPos(o2p(start)) { Select(Select (Ident(nme.ROOTPKG), nme.scala_), nme.StringContext) }
  val t1 = atPos(o2p(start)) { Ident(nme.StringContext) }
```

From https://github.com/scala/scala/blob/v2.11.8/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala#L1304-L1306

Therefore the `StringContext` in the standard library, which provides a number of intepolators - all that take `Any`s, can be thrown out and replaced with a better, more principled one.

Before:

```scala
psp> val xs = 1 to 20
xs: IntRange = [1..20]

psp> pp"$xs"
res3: String = [1..20]

psp> s"$xs"
res4: String = psp.std.Consecutive$Closed@77228160
```

After:

```scala
psp> val xs = 1 to 20
xs: IntRange = [1..20]

psp> pp"$xs"
res3: String = [1..20]

psp> s"$xs"
Main.scala:1033: value s is not a member of psp.std.StringContext
s"$xs"
^

Compilation Failed
```

Also, replace all the s-interpolator usages for psp-std interpolators, except for in macros, where attempts to re-wire `Quasiquote` to use `psp.std.StringContext` failed..

---

Let me know if you'd like a test to demonstrate that the `Any`-based s-interpolator doesn't compile.

Also, what do you think about renaming `pp` to `s`?