### PR TITLE
Bump ammonite to 0.6.2

### DIFF
--- a/project/PspStd.scala
+++ b/project/PspStd.scala
@@ -13,7 +13,7 @@ object PspStd {
   def compileArgs: Seq[String]  = ammoniteArgs ++ wordSeq("-Ywarn-unused -Ywarn-unused-import")
   def compileArgsBoth           = inBoth(config => Seq(scalacOptions in compile in config ++= compileArgs))
 
-  def ammonite         = "com.lihaoyi"              %       "ammonite-repl"       % "0.5.7" cross CrossVersion.full
+  def ammonite         = "com.lihaoyi"              %       "ammonite-repl"       % "0.6.2" cross CrossVersion.full
   def jmhAnnotations   = "org.openjdk.jmh"          %  "jmh-generator-annprocess" %             "1.12"
   def jsr305           = "com.google.code.findbugs" %           "jsr305"          %             "3.0.1"
   def scoverageRuntime = "org.scoverage"            %% "scalac-scoverage-runtime" %             "1.1.1"

--- a/repl/ammonite.scala
+++ b/repl/ammonite.scala
@@ -7,24 +7,27 @@ import ammonite.repl.frontend.FrontEnd
 import java.lang.System
 
 object Main {
-  def storage = Storage(defaultAmmoniteHome, None)
+  def storage = new Storage.Folder(defaultAmmoniteHome)
   def initImports = sm"""
     |import psp.std._, all._, StdShow._
     |import psprepl._, INREPL._
   """
 
-  def main(args: Array[String]): Unit = new REPL(Ref(storage), initImports, args.toVec).start()
+  def ammoniteVersion = ammonite.Constants.version
+  def scalaVersion    = scala.util.Properties.versionNumberString
+  def javaVersion     = System.getProperty("java.version")
+  def banner          = s"\npsp-std repl (ammonite $ammoniteVersion, scala $scalaVersion, jvm $javaVersion)"
+
+  def main(args: Array[String]): Unit = new REPL(storage, initImports, args.toVec).start()
 }
 
 /** This sets up the ammonite repl with the correct compiler settings
  *  and desired namespace elements and aesthetics.
  */
-class REPL(storage: Ref[Storage], initCode: String, scalacArgs: Vec[String]) extends Repl(System.in, System.out, System.err, storage, "", emptyValue) {
+class REPL(storage: Storage, initCode: String, scalacArgs: Vec[String])
+    extends Repl(System.in, System.out, System.err, storage, "", ammonite.ops.cwd, Some(Main.banner), emptyValue) {
   override val frontEnd = Ref[FrontEnd](FrontEnd.JLineUnix)
   override val prompt   = Ref("psp> ")
-
-  private def banner               = s"\npsp-std repl (ammonite $ammoniteVersion, scala $scalaVersion, jvm $javaVersion)"
-  override def printBanner(): Unit = printStream println banner
 
   import interp.replApi._
 


### PR DESCRIPTION
Had a look a bit at how things have changed, but not all the way, so this was
enough for me to run:

    repl/run -language:_ -Yno-predef -Yno-adapted-args -Yno-imports -Xlog-implicits

.. and not run into:

    scala.MatchError: INFO (of class scala.tools.nsc.reporters.Reporter$INFO$)
      ammonite.repl.interp.Compiler$$anon$2.display(Compiler.scala:120)

The fix is actually in 0.5.8, but I went for latest.

https://github.com/lihaoyi/Ammonite/commit/63d102733cbf759fa7cc6e8b7c3e993533307505#diff-a08d4cf136a9d0be5e970c1bbc567d00R127